### PR TITLE
chore: replace deprecated dependency: tempdir -> tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
  "getrandom",
  "instant",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "tokio",
 ]
 
@@ -345,7 +345,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tar",
- "tempdir",
+ "tempfile",
  "thiserror",
  "tokio",
  "url",
@@ -491,12 +491,6 @@ checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -1060,26 +1054,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1089,23 +1070,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1114,15 +1080,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1197,15 +1154,6 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -1443,16 +1391,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 sha2 = "0.10.8"
 tar = "0.4.40"
-tempdir = "0.3.7"
+tempfile = "3"
 thiserror = "1.0"
 tokio = { version = "1.34", features = ["macros"] }
 url = "2.4"

--- a/tests/suite/common/temp_home_dir.rs
+++ b/tests/suite/common/temp_home_dir.rs
@@ -6,7 +6,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Mutex;
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 static HOME_LOCK: Mutex<()> = Mutex::new(());
 
@@ -35,7 +35,10 @@ pub struct TempHomeDir {
 
 impl TempHomeDir {
     pub fn new() -> Self {
-        let tempdir = TempDir::new("dfxvm-integration-tests-home").unwrap();
+        let tempdir = tempfile::Builder::new()
+            .prefix("dfxvm-integration-tests-home")
+            .tempdir()
+            .unwrap();
         let project_dirs = project_dirs(tempdir.path());
         let versions_dir = project_dirs.data_local_dir().join("versions");
         let config_dir = tempdir.path().join(".config").join("dfx");
@@ -98,6 +101,13 @@ impl TempHomeDir {
 
     pub fn settings(&self) -> Settings {
         Settings::new(self.config_dir.join("version-manager.json"))
+    }
+
+    pub fn new_project_temp_dir(&self) -> TempDir {
+        tempfile::Builder::new()
+            .prefix("integration-test-project")
+            .tempdir_in(self.tempdir.path())
+            .unwrap()
     }
 }
 

--- a/tests/suite/dfx.rs
+++ b/tests/suite/dfx.rs
@@ -2,7 +2,6 @@ use crate::common::TempHomeDir;
 use assert_cmd::prelude::*;
 use predicates::str::*;
 use std::os::unix::fs::PermissionsExt;
-use tempdir::TempDir;
 
 #[test]
 fn no_version_anywhere() {
@@ -75,7 +74,7 @@ fn version_from_dfx_json() {
 
     let mut cmd = home_dir.dfx();
 
-    let tempdir = TempDir::new("integration-test-project").unwrap();
+    let tempdir = home_dir.new_project_temp_dir();
     let dfx_json = tempdir.path().join("dfx.json");
     std::fs::write(dfx_json, r#"{"dfx": "0.7.8"}"#).unwrap();
     cmd.current_dir(&tempdir);
@@ -132,7 +131,7 @@ fn version_from_environment_takes_precedence_over_dfx_json() {
 
     let mut cmd = home_dir.dfx();
 
-    let tempdir = TempDir::new("integration-test-project").unwrap();
+    let tempdir = home_dir.new_project_temp_dir();
     let dfx_json = tempdir.path().join("dfx.json");
     std::fs::write(dfx_json, r#"{"dfx": "0.9.9"}"#).unwrap();
     cmd.current_dir(&tempdir);
@@ -156,7 +155,7 @@ fn version_from_dfx_json_takes_precedence_over_settings() {
 
     let mut cmd = home_dir.dfx();
 
-    let tempdir = TempDir::new("integration-test-project").unwrap();
+    let tempdir = home_dir.new_project_temp_dir();
     let dfx_json = tempdir.path().join("dfx.json");
     std::fs::write(dfx_json, r#"{"dfx": "0.7.4"}"#).unwrap();
     cmd.current_dir(&tempdir);
@@ -177,7 +176,7 @@ fn dfx_json_with_no_version() {
 
     let mut cmd = home_dir.dfx();
 
-    let tempdir = TempDir::new("integration-test-project").unwrap();
+    let tempdir = home_dir.new_project_temp_dir();
     let dfx_json = tempdir.path().join("dfx.json");
     std::fs::write(dfx_json, r#"{}"#).unwrap();
     cmd.current_dir(&tempdir);
@@ -196,7 +195,7 @@ fn version_from_dfx_json_ignores_other_fields() {
         "echo 'this is the zero point seven point eight dfx executable'",
     );
 
-    let tempdir = TempDir::new("integration-test-project").unwrap();
+    let tempdir = home_dir.new_project_temp_dir();
     let dfx_json = tempdir.path().join("dfx.json");
     std::fs::write(dfx_json, r#"{"dfx": "0.7.8", "other": "ignored"}"#).unwrap();
     cmd.current_dir(&tempdir);
@@ -215,7 +214,7 @@ fn searches_for_dfx_json_in_parent_directories() {
         "echo 'this is the zero point seven point nine dfx executable'",
     );
 
-    let tempdir = TempDir::new("integration-test-project").unwrap();
+    let tempdir = home_dir.new_project_temp_dir();
     let x = tempdir.path().join("x");
     let y = x.join("y");
     let z = y.join("z");
@@ -347,7 +346,7 @@ fn malformed_json_in_dfx_json() {
     let home_dir = TempHomeDir::new();
     let mut cmd = home_dir.dfx();
 
-    let tempdir = TempDir::new("integration-test-project").unwrap();
+    let tempdir = home_dir.new_project_temp_dir();
     let dfx_json = tempdir.path().join("dfx.json");
     std::fs::write(dfx_json, r#"{ not valid json }"#).unwrap();
     cmd.current_dir(&tempdir);
@@ -363,7 +362,7 @@ fn malformed_version_in_dfx_json() {
     let home_dir = TempHomeDir::new();
     let mut cmd = home_dir.dfx();
 
-    let tempdir = TempDir::new("integration-test-project").unwrap();
+    let tempdir = home_dir.new_project_temp_dir();
     let dfx_json = tempdir.path().join("dfx.json");
     std::fs::write(dfx_json, r#"{"dfx": "3.x"}"#).unwrap();
     cmd.current_dir(&tempdir);


### PR DESCRIPTION
# Description

The tempdir crate is deprecated: https://github.com/rust-lang-deprecated/tempdir
It also depends on version 0.5.3 of the remove_dir_all crate, which has a security warning

Replaced the dependency with the [tempfile](https://docs.rs/tempfile/latest/tempfile/) crate.

Intended to eliminate this dependabot warning: https://github.com/dfinity/dfxvm/security/dependabot/1

# How Has This Been Tested?

Covered by existing tests

