### PR TITLE
fix: tests failing with "text file busy"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - text-file-busy
   pull_request:
 
 jobs:
@@ -27,7 +26,7 @@ jobs:
           key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-1
 
       - name: Run Tests
-        run: RUST_BACKTRACE=1 cargo test
+        run: cargo test
 
   aggregate:
     name: test:required

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - text-file-busy
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-1
 
       - name: Run Tests
-        run: cargo test
+        run: RUST_BACKTRACE=1 cargo test
 
   aggregate:
     name: test:required

--- a/tests/suite/common/executable.rs
+++ b/tests/suite/common/executable.rs
@@ -1,0 +1,30 @@
+use backoff::{retry, ExponentialBackoff};
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+pub fn create_executable(path: &Path, contents: &str) {
+    std::fs::write(path, contents).unwrap();
+    set_executable(path);
+
+    let backoff = ExponentialBackoff::default();
+    retry(backoff, || {
+        let mut command = Command::new(path);
+        let result = command.output();
+        // check for os code 26 (text file busy)
+        match result {
+            Ok(output) => Ok(output),
+            Err(err) if matches!(err.raw_os_error(), Some(26)) => {
+                Err(backoff::Error::transient(err))
+            }
+            Err(other) => Err(backoff::Error::permanent(other)),
+        }
+    })
+    .unwrap();
+}
+
+fn set_executable(bin_path: &Path) {
+    let mut perms = std::fs::metadata(bin_path).unwrap().permissions();
+    perms.set_mode(perms.mode() | 0o500);
+    std::fs::set_permissions(bin_path, perms).unwrap();
+}

--- a/tests/suite/common/executable.rs
+++ b/tests/suite/common/executable.rs
@@ -11,10 +11,11 @@ pub fn create_executable(path: &Path, contents: &str) {
     retry(backoff, || {
         let mut command = Command::new(path);
         let result = command.output();
-        // check for os code 26 (text file busy)
+
+        const TEXT_FILE_BUSY: i32 = 26;
         match result {
             Ok(output) => Ok(output),
-            Err(err) if matches!(err.raw_os_error(), Some(26)) => {
+            Err(err) if matches!(err.raw_os_error(), Some(TEXT_FILE_BUSY)) => {
                 Err(backoff::Error::transient(err))
             }
             Err(other) => Err(backoff::Error::permanent(other)),

--- a/tests/suite/common/executable.rs
+++ b/tests/suite/common/executable.rs
@@ -6,7 +6,10 @@ use std::process::Command;
 pub fn create_executable(path: &Path, contents: &str) {
     std::fs::write(path, contents).unwrap();
     set_executable(path);
+    wait_until_file_is_not_busy(path);
+}
 
+pub fn wait_until_file_is_not_busy(path: &Path) {
     let backoff = ExponentialBackoff::default();
     retry(backoff, || {
         let mut command = Command::new(path);

--- a/tests/suite/common/mod.rs
+++ b/tests/suite/common/mod.rs
@@ -1,3 +1,4 @@
+mod executable;
 pub mod file_contents;
 mod release_asset;
 mod release_server;

--- a/tests/suite/common/temp_home_dir.rs
+++ b/tests/suite/common/temp_home_dir.rs
@@ -63,8 +63,10 @@ impl TempHomeDir {
 
     pub fn command(&self, filename: &str) -> Command {
         let path = self.tempdir.path().join(filename);
-        std::fs::copy(dfxvm_path(), &path).unwrap();
-        wait_until_file_is_not_busy(&path);
+        if !path.exists() {
+            std::fs::copy(dfxvm_path(), &path).unwrap();
+            wait_until_file_is_not_busy(&path);
+        }
 
         let mut command = Command::new(path);
         command.env("HOME", self.tempdir.path());

--- a/tests/suite/common/temp_home_dir.rs
+++ b/tests/suite/common/temp_home_dir.rs
@@ -1,4 +1,4 @@
-use crate::common::executable::create_executable;
+use crate::common::executable::{create_executable, wait_until_file_is_not_busy};
 use crate::common::{dfxvm_path, file_contents, Settings};
 use directories::ProjectDirs;
 use std::env;
@@ -64,6 +64,8 @@ impl TempHomeDir {
     pub fn command(&self, filename: &str) -> Command {
         let path = self.tempdir.path().join(filename);
         std::fs::copy(dfxvm_path(), &path).unwrap();
+        wait_until_file_is_not_busy(&path);
+
         let mut command = Command::new(path);
         command.env("HOME", self.tempdir.path());
         command

--- a/tests/suite/common/temp_home_dir.rs
+++ b/tests/suite/common/temp_home_dir.rs
@@ -1,8 +1,8 @@
+use crate::common::executable::create_executable;
 use crate::common::{dfxvm_path, file_contents, Settings};
 use directories::ProjectDirs;
 use std::env;
 use std::fs::create_dir_all;
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Mutex;
@@ -94,8 +94,7 @@ impl TempHomeDir {
         create_dir_all(&version).unwrap();
         let bin_path = version.join("dfx");
         let script = file_contents::bash_script(snippet);
-        std::fs::write(&bin_path, script).unwrap();
-        set_executable(&bin_path);
+        create_executable(&bin_path, &script);
         bin_path
     }
 
@@ -109,10 +108,4 @@ impl TempHomeDir {
             .tempdir_in(self.tempdir.path())
             .unwrap()
     }
-}
-
-fn set_executable(bin_path: &Path) {
-    let mut perms = std::fs::metadata(bin_path).unwrap().permissions();
-    perms.set_mode(perms.mode() | 0o500);
-    std::fs::set_permissions(bin_path, perms).unwrap();
 }


### PR DESCRIPTION
# Description

I have noticed tests failing like this, but more often recently:
```
Failed to spawn HOME="/tmp/dfxvm-integration-tests-homeUbf1FB" 
   "/tmp/dfxvm-integration-tests-homeUbf1FB/dfx": 
  Text file busy (os error 26)
```

This PR makes two changes:
- don't re-create a copy of dfxvm with a given name 
- when creating any executable, try to execute it until anything other than os error 26 happens

# How Has This Been Tested?

I ran tests with three branches, modified to run the tests without an open PR and to set RUST_BACKTRACE=1:
- same as main ([workflow](url)): 8 failures out of 20 attempts
- do not re-create dfxvm binaries ([workflow](url)): 15 failures out of 20 attempts
- this branch ([workflow](https://github.com/dfinity/dfxvm/actions/runs/7039399141)): 0 failures out of 20 attempts

