### PR TITLE
test:  verify expected behavior if XDG_DATA_HOME is set

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - tests-no-project-dirs
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - tests-no-project-dirs
   pull_request:
 
 jobs:

--- a/tests/suite/common/mod.rs
+++ b/tests/suite/common/mod.rs
@@ -1,5 +1,6 @@
 mod executable;
 pub mod file_contents;
+pub mod project_dirs;
 mod release_asset;
 mod release_server;
 mod settings;

--- a/tests/suite/common/project_dirs.rs
+++ b/tests/suite/common/project_dirs.rs
@@ -1,0 +1,17 @@
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "macos")]
+pub fn data_local_dir(home: &Path, _xdg_data_home: Option<&Path>) -> PathBuf {
+    home.join("Library")
+        .join("Application Support")
+        .join("org.dfinity.dfx")
+}
+
+#[cfg(target_os = "linux")]
+pub fn data_local_dir(home: &Path, xdg_data_home: Option<&Path>) -> PathBuf {
+    // See https://github.com/dirs-dev/directories-rs/blob/main/src/lin.rs#L15
+    match xdg_data_home {
+        Some(xdg_data_home) if xdg_data_home.is_absolute() => xdg_data_home.join("dfx"),
+        _ => home.join(".local").join("share").join("dfx"),
+    }
+}

--- a/tests/suite/dispatch.rs
+++ b/tests/suite/dispatch.rs
@@ -39,7 +39,7 @@ fn dispatch_to_dfxvm_init_exact() {
 #[test]
 fn dispatch_to_dfxvm_init_by_prefix() {
     let home_dir = TempHomeDir::new();
-    let mut cmd = home_dir.command("dfxvm-init (3)");
+    let mut cmd = home_dir.dfxvm_as_command_named("dfxvm-init (3)");
 
     cmd.assert()
         .success()
@@ -49,7 +49,7 @@ fn dispatch_to_dfxvm_init_by_prefix() {
 #[test]
 fn dispatch_to_unknown() {
     let home_dir = TempHomeDir::new();
-    let mut cmd = home_dir.command("called-something-else");
+    let mut cmd = home_dir.dfxvm_as_command_named("called-something-else");
 
     cmd.assert()
         .failure()


### PR DESCRIPTION
# Description

On Linux, if XDG_DATA_HOME is set, dfxvm should store dfx binaries relative to it.  This PR adds tests that verify that this is so.

It also isolates commands run by tests from the host environment by clearing the Command's environment and setting a limited PATH.

This also removed the dependency from the test suite on the [directories](https://docs.rs/directories/latest/directories/) crate, instead having the test code express the expected paths directly.

# How Has This Been Tested?

Added tests
