### PR TITLE
docs: copyright and acknowledgements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,19 @@ DFX_VERSION=0.15.1 sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinit
 ## Contribution
 
 Contributions to dfxvm are welcome! For information about contributing,
-see [CONTRIBUTING.md][CONTRIBUTING.md). Contributors must agree to a [CLA][cla].
+see [CONTRIBUTING.md](CONTRIBUTING.md). Contributors must agree to a [CLA][cla].
 
 ## License
 
+Copyright 2023 DFINITY Stiftung <sdk@dfinity.org>.
+
 dfxvm is licensed under the [Apache 2.0 License](LICENSE).
+
+## Acknowledgements
+
+dfxvm is inspired by, and parts are copied from and/or derived from, [rustup][rustup],
+which is also licensed under the [Apache 2.0 License](LICENSE).
 
 [sdk]: https://github.com/dfinity/sdk
 [cla]: https://github.com/dfinity/cla/blob/main/CLA.md
+[rustup]: https://github.com/rust-lang/rustup

--- a/src/installation/env.rs
+++ b/src/installation/env.rs
@@ -1,5 +1,6 @@
 use crate::installation::dirs::{get_bin_dir_user_facing, get_data_local_dir_user_facing};
 
+// The env.sh file is copied and modified from https://github.com/rust-lang/rustup/blob/master/src/cli/self_update/env.sh
 const ENV_FILE_TEMPLATE: &str = include_str!("env.sh");
 
 pub fn get_env_path_user_facing() -> String {


### PR DESCRIPTION
Adds an acknowledgements section to the readme, and an attribution for code/files derived/copied/modified from rustup.

Also adds a copyright notice, and fixes a typo in the link to the contributing doc.
