### PR TITLE
refactor: PlanOptions

### DIFF
--- a/src/dfxvm_init/cli.rs
+++ b/src/dfxvm_init/cli.rs
@@ -1,4 +1,8 @@
 use crate::dfxvm_init::initialize::initialize;
+use crate::dfxvm_init::plan::{
+    DfxVersion::{Latest, Specific},
+    PlanOptions,
+};
 use crate::dfxvm_init::ui::Confirmation;
 use crate::error::dfxvm_init;
 use clap::Parser;
@@ -28,7 +32,11 @@ pub async fn main(args: &[OsString]) -> Result<ExitCode, dfxvm_init::Error> {
         None
     };
 
-    initialize(opts.dfx_version, confirmation).await?;
+    let dfx_version = opts.dfx_version.map_or_else(|| Latest, Specific);
+
+    let options = PlanOptions::new().with_dfx_version(dfx_version);
+
+    initialize(options, confirmation).await?;
 
     Ok(ExitCode::SUCCESS)
 }

--- a/src/dfxvm_init/initialize.rs
+++ b/src/dfxvm_init/initialize.rs
@@ -1,6 +1,6 @@
 use crate::dfxvm;
 use crate::dfxvm_init::{
-    plan::{DfxVersion, Plan},
+    plan::{DfxVersion, Plan, PlanOptions},
     ui,
     ui::Confirmation,
 };
@@ -8,18 +8,14 @@ use crate::error::{dfxvm_init, dfxvm_init::ExecutePlanError, fs::WriteFileError}
 use crate::fs::create_dir_all;
 use crate::installation::{env_file_contents, install_binaries};
 use crate::locations::Locations;
-use semver::Version;
 use std::path::Path;
 
 pub async fn initialize(
-    dfx_version: Option<Version>,
+    options: PlanOptions,
     confirmation: Option<Confirmation>,
 ) -> Result<(), dfxvm_init::Error> {
     let locations = Locations::new()?;
-    let mut plan = Plan::new(&locations);
-    if let Some(version) = dfx_version {
-        plan = plan.with_dfx_version(DfxVersion::Specific(version));
-    }
+    let mut plan = Plan::new(options, &locations);
 
     ui::display::introduction(&plan);
 
@@ -52,7 +48,7 @@ pub async fn execute(plan: &Plan, locations: &Locations) -> Result<(), ExecutePl
 
     install_binaries(&plan.bin_dir)?;
 
-    match &plan.dfx_version {
+    match &plan.options.dfx_version {
         DfxVersion::Latest => dfxvm::update().await?,
         DfxVersion::Specific(version) => dfxvm::set_default(version, locations).await?,
     }

--- a/src/dfxvm_init/plan.rs
+++ b/src/dfxvm_init/plan.rs
@@ -9,9 +9,27 @@ pub enum DfxVersion {
     Specific(Version),
 }
 
-pub struct Plan {
-    pub bin_dir: PathBuf,
+#[derive(Clone)]
+pub struct PlanOptions {
     pub dfx_version: DfxVersion,
+}
+
+impl PlanOptions {
+    pub fn new() -> Self {
+        Self {
+            dfx_version: DfxVersion::Latest,
+        }
+    }
+
+    pub fn with_dfx_version(self, dfx_version: DfxVersion) -> Self {
+        Self { dfx_version }
+    }
+}
+
+pub struct Plan {
+    pub options: PlanOptions,
+
+    pub bin_dir: PathBuf,
 
     pub env_path: PathBuf,
 
@@ -23,23 +41,19 @@ pub struct Plan {
 }
 
 impl Plan {
-    pub fn new(locations: &Locations) -> Self {
+    pub fn new(options: PlanOptions, locations: &Locations) -> Self {
         let bin_dir = locations.data_local_dir().join("bin");
         let env_path = locations.data_local_dir().join("env");
-        let dfx_version = DfxVersion::Latest;
         let env_path_user_facing = get_env_path_user_facing().to_string();
         Self {
+            options,
             bin_dir,
             env_path,
             env_path_user_facing,
-            dfx_version,
         }
     }
 
-    pub fn with_dfx_version(self, dfx_version: DfxVersion) -> Self {
-        Self {
-            dfx_version,
-            ..self
-        }
+    pub fn with_options(self, options: PlanOptions) -> Self {
+        Self { options, ..self }
     }
 }

--- a/src/dfxvm_init/ui/customize.rs
+++ b/src/dfxvm_init/ui/customize.rs
@@ -3,16 +3,19 @@ use crate::error::dfxvm_init::InteractError;
 use crate::log::log_error;
 use semver::Version;
 
-pub fn customize(mut plan: Plan) -> Result<Plan, InteractError> {
+pub fn customize(plan: Plan) -> Result<Plan, InteractError> {
     println!("I'm going to ask you the value of each of these installation options.");
     println!("You may simply press the Enter key to leave unchanged.");
     println!();
 
-    let dfx_version = select_dfx_version(&plan.dfx_version)?;
-    plan = plan.with_dfx_version(dfx_version);
+    let mut options = plan.options.clone();
+
+    let dfx_version = select_dfx_version(&options.dfx_version)?;
+    options = options.with_dfx_version(dfx_version);
+
     println!();
 
-    Ok(plan)
+    Ok(plan.with_options(options))
 }
 
 fn select_dfx_version(install_dfx: &DfxVersion) -> Result<DfxVersion, InteractError> {

--- a/src/dfxvm_init/ui/display.rs
+++ b/src/dfxvm_init/ui/display.rs
@@ -17,8 +17,9 @@ pub fn introduction(plan: &Plan) {
     println!();
 }
 
-pub fn options(initialization_plan: &Plan) {
-    let dfx_version = match &initialization_plan.dfx_version {
+pub fn options(plan: &Plan) {
+    let options = &plan.options;
+    let dfx_version = match &options.dfx_version {
         DfxVersion::Latest => "latest".to_string(),
         DfxVersion::Specific(version) => version.to_string(),
     };


### PR DESCRIPTION
# Description

Moves the customizable parts of a Plan into a new PlanOptions struct, primarily so that the CLI layer can initialize them from command-line options.

For further context, see https://github.com/dfinity/dfxvm/pull/35

# How Has This Been Tested?

Refactor covered by existing tests.

