### PR TITLE
feat: init mode alters profile scripts to update PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+- dfxvm-init now alters profile scripts to modify the PATH environment variable.
+
 ## [0.1.1] - 2023-12-04
 
 - Added `dfx` mode, which selects a dfx version and dispatches execution to it.

--- a/docs/cli-reference/dfxvm-init/dfxvm-init.md
+++ b/docs/cli-reference/dfxvm-init/dfxvm-init.md
@@ -17,6 +17,7 @@ dfxvm-init [--dfx-version <version>] [--proceed]
 |---------------------------| --- |
 | `--dfx-version <version>` | The version of dfx to install. Defaults to the latest dfx version |
 | `--proceed`               | Skip confirmation prompt |
+| `--no-modify-path`        | Do not alter profile scripts to modify the PATH environment variable |
 
 ## Examples
 

--- a/src/dfxvm_init/cli.rs
+++ b/src/dfxvm_init/cli.rs
@@ -21,6 +21,10 @@ pub struct Cli {
     /// Automatically confirm options and proceed with install.
     #[clap(long)]
     proceed: bool,
+
+    /// Don't configure the PATH environment variable in profile scripts.
+    #[clap(long)]
+    no_modify_path: bool,
 }
 
 pub async fn main(args: &[OsString]) -> Result<ExitCode, dfxvm_init::Error> {
@@ -34,7 +38,9 @@ pub async fn main(args: &[OsString]) -> Result<ExitCode, dfxvm_init::Error> {
 
     let dfx_version = opts.dfx_version.map_or_else(|| Latest, Specific);
 
-    let options = PlanOptions::new().with_dfx_version(dfx_version);
+    let options = PlanOptions::new()
+        .with_dfx_version(dfx_version)
+        .with_modify_path(!opts.no_modify_path);
 
     initialize(options, confirmation).await?;
 

--- a/src/dfxvm_init/cli.rs
+++ b/src/dfxvm_init/cli.rs
@@ -1,4 +1,8 @@
 use crate::dfxvm_init::initialize::initialize;
+use crate::dfxvm_init::plan::{
+    DfxVersion::{Latest, Specific},
+    PlanOptions,
+};
 use crate::dfxvm_init::ui::Confirmation;
 use crate::error::dfxvm_init;
 use clap::Parser;
@@ -28,7 +32,11 @@ pub async fn main(args: &[OsString]) -> Result<ExitCode, dfxvm_init::Error> {
         None
     };
 
-    initialize(opts.dfx_version, confirmation).await?;
+    let dfx_version = opts.dfx_version.map_or_else(|| Latest, Specific);
+
+    let options = PlanOptions::new().with_dfx_version(dfx_version);
+
+    initialize(options, confirmation).await?;
 
     Ok(ExitCode::SUCCESS)
 }

--- a/src/dfxvm_init/initialize.rs
+++ b/src/dfxvm_init/initialize.rs
@@ -1,6 +1,6 @@
 use crate::dfxvm;
 use crate::dfxvm_init::{
-    plan::{DfxVersion, Plan},
+    plan::{DfxVersion, Plan, PlanOptions},
     ui,
     ui::Confirmation,
 };
@@ -8,18 +8,14 @@ use crate::error::{dfxvm_init, dfxvm_init::ExecutePlanError, fs::WriteFileError}
 use crate::fs::create_dir_all;
 use crate::installation::{env_file_contents, install_binaries};
 use crate::locations::Locations;
-use semver::Version;
 use std::path::Path;
 
 pub async fn initialize(
-    dfx_version: Option<Version>,
+    options: PlanOptions,
     confirmation: Option<Confirmation>,
 ) -> Result<(), dfxvm_init::Error> {
     let locations = Locations::new()?;
-    let mut plan = Plan::new(&locations);
-    if let Some(version) = dfx_version {
-        plan = plan.with_dfx_version(DfxVersion::Specific(version));
-    }
+    let mut plan = Plan::new(options, &locations);
 
     ui::display::introduction(&plan);
 
@@ -52,7 +48,7 @@ pub async fn execute(plan: &Plan, locations: &Locations) -> Result<(), ExecutePl
 
     install_binaries(&plan.bin_dir)?;
 
-    match &plan.dfx_version {
+    match &plan.options.dfx_version {
         DfxVersion::Latest => dfxvm::update().await?,
         DfxVersion::Specific(version) => dfxvm::set_default(version, locations).await?,
     }

--- a/src/dfxvm_init/plan.rs
+++ b/src/dfxvm_init/plan.rs
@@ -1,4 +1,4 @@
-use crate::installation::get_env_path_user_facing;
+use crate::installation::{get_detected_profile_scripts, get_env_path_user_facing, ProfileScript};
 use crate::locations::Locations;
 use semver::Version;
 use std::path::PathBuf;
@@ -12,17 +12,29 @@ pub enum DfxVersion {
 #[derive(Clone)]
 pub struct PlanOptions {
     pub dfx_version: DfxVersion,
+    pub modify_path: bool,
 }
 
 impl PlanOptions {
     pub fn new() -> Self {
         Self {
             dfx_version: DfxVersion::Latest,
+            modify_path: true,
         }
     }
 
     pub fn with_dfx_version(self, dfx_version: DfxVersion) -> Self {
-        Self { dfx_version }
+        Self {
+            dfx_version,
+            ..self
+        }
+    }
+
+    pub fn with_modify_path(self, modify_path: bool) -> Self {
+        Self {
+            modify_path,
+            ..self
+        }
     }
 }
 
@@ -38,6 +50,8 @@ pub struct Plan {
     // to use with the "source" command, and also the path that we will use when
     // altering profile scripts.
     pub env_path_user_facing: String,
+
+    pub profile_scripts: Vec<ProfileScript>,
 }
 
 impl Plan {
@@ -45,11 +59,13 @@ impl Plan {
         let bin_dir = locations.data_local_dir().join("bin");
         let env_path = locations.data_local_dir().join("env");
         let env_path_user_facing = get_env_path_user_facing().to_string();
+        let profile_scripts = get_detected_profile_scripts();
         Self {
             options,
             bin_dir,
             env_path,
             env_path_user_facing,
+            profile_scripts,
         }
     }
 

--- a/src/dfxvm_init/plan.rs
+++ b/src/dfxvm_init/plan.rs
@@ -9,9 +9,27 @@ pub enum DfxVersion {
     Specific(Version),
 }
 
-pub struct Plan {
-    pub bin_dir: PathBuf,
+#[derive(Clone)]
+pub struct PlanOptions {
     pub dfx_version: DfxVersion,
+}
+
+impl PlanOptions {
+    pub fn new() -> Self {
+        Self {
+            dfx_version: DfxVersion::Latest,
+        }
+    }
+
+    pub fn with_dfx_version(self, dfx_version: DfxVersion) -> Self {
+        Self { dfx_version }
+    }
+}
+
+pub struct Plan {
+    pub options: PlanOptions,
+
+    pub bin_dir: PathBuf,
 
     pub env_path: PathBuf,
 
@@ -23,23 +41,19 @@ pub struct Plan {
 }
 
 impl Plan {
-    pub fn new(locations: &Locations) -> Self {
+    pub fn new(options: PlanOptions, locations: &Locations) -> Self {
         let bin_dir = locations.data_local_dir().join("bin");
         let env_path = locations.data_local_dir().join("env");
-        let dfx_version = DfxVersion::Latest;
         let env_path_user_facing = get_env_path_user_facing().to_string();
         Self {
+            options,
             bin_dir,
             env_path,
             env_path_user_facing,
-            dfx_version,
         }
     }
 
-    pub fn with_dfx_version(self, dfx_version: DfxVersion) -> Self {
-        Self {
-            dfx_version,
-            ..self
-        }
+    pub fn with_options(self, options: PlanOptions) -> Self {
+        Self { options, ..self }
     }
 }

--- a/src/dfxvm_init/ui/customize.rs
+++ b/src/dfxvm_init/ui/customize.rs
@@ -1,6 +1,7 @@
 use crate::dfxvm_init::plan::{DfxVersion, Plan};
 use crate::error::dfxvm_init::InteractError;
 use crate::log::log_error;
+use dialoguer::Confirm;
 use semver::Version;
 
 pub fn customize(plan: Plan) -> Result<Plan, InteractError> {
@@ -12,6 +13,9 @@ pub fn customize(plan: Plan) -> Result<Plan, InteractError> {
 
     let dfx_version = select_dfx_version(&options.dfx_version)?;
     options = options.with_dfx_version(dfx_version);
+
+    let modify_path = select_modify_path(options.modify_path)?;
+    options = options.with_modify_path(modify_path);
 
     println!();
 
@@ -43,4 +47,12 @@ fn select_dfx_version(install_dfx: &DfxVersion) -> Result<DfxVersion, InteractEr
         }
     };
     Ok(dfx_version)
+}
+
+fn select_modify_path(current: bool) -> Result<bool, InteractError> {
+    let modify = Confirm::new()
+        .with_prompt("Modify PATH variable?")
+        .default(current)
+        .interact()?;
+    Ok(modify)
 }

--- a/src/dfxvm_init/ui/customize.rs
+++ b/src/dfxvm_init/ui/customize.rs
@@ -3,16 +3,19 @@ use crate::error::dfxvm_init::InteractError;
 use crate::log::log_error;
 use semver::Version;
 
-pub fn customize(mut plan: Plan) -> Result<Plan, InteractError> {
+pub fn customize(plan: Plan) -> Result<Plan, InteractError> {
     println!("I'm going to ask you the value of each of these installation options.");
     println!("You may simply press the Enter key to leave unchanged.");
     println!();
 
-    let dfx_version = select_dfx_version(&plan.dfx_version)?;
-    plan = plan.with_dfx_version(dfx_version);
+    let mut options = plan.options.clone();
+
+    let dfx_version = select_dfx_version(&options.dfx_version)?;
+    options = options.with_dfx_version(dfx_version);
+
     println!();
 
-    Ok(plan)
+    Ok(plan.with_options(options))
 }
 
 fn select_dfx_version(install_dfx: &DfxVersion) -> Result<DfxVersion, InteractError> {

--- a/src/dfxvm_init/ui/display.rs
+++ b/src/dfxvm_init/ui/display.rs
@@ -17,8 +17,9 @@ pub fn introduction(plan: &Plan) {
     println!();
 }
 
-pub fn options(initialization_plan: &Plan) {
-    let dfx_version = match &initialization_plan.dfx_version {
+pub fn options(plan: &Plan) {
+    let options = &plan.options;
+    let dfx_version = match &options.dfx_version {
         DfxVersion::Latest => "latest".to_string(),
         DfxVersion::Specific(version) => version.to_string(),
     };

--- a/src/dfxvm_init/ui/display.rs
+++ b/src/dfxvm_init/ui/display.rs
@@ -1,6 +1,9 @@
 use crate::dfxvm_init::plan::{DfxVersion, Plan};
 use console::style;
 
+// Most of the text in this file is derived/copied/modified from:
+// https://github.com/rust-lang/rustup/blob/master/src/cli/self_update.rs
+
 pub fn introduction(plan: &Plan) {
     println!();
     println!("{}", style("Welcome to dfxvm!").bold());
@@ -14,6 +17,16 @@ pub fn introduction(plan: &Plan) {
     );
     println!();
     println!("   {}", plan.bin_dir.display());
+    if !plan.profile_scripts.is_empty() {
+        println!();
+        println!("This path will then be added to your PATH environment variable by");
+        println!("modifying the profile files located at:");
+        println!();
+
+        for script in &plan.profile_scripts {
+            println!("   {}", script.path.display());
+        }
+    }
     println!();
 }
 
@@ -23,10 +36,12 @@ pub fn options(plan: &Plan) {
         DfxVersion::Latest => "latest".to_string(),
         DfxVersion::Specific(version) => version.to_string(),
     };
+    let modify_path = if options.modify_path { "yes" } else { "no" };
 
     println!("Current installation options:");
     println!();
-    println!("   dfx version: {}", style(dfx_version).bold());
+    println!("            dfx version: {}", style(dfx_version).bold());
+    println!("   modify PATH variable: {}", style(modify_path).bold());
     println!();
 }
 
@@ -34,9 +49,30 @@ pub fn success(plan: &Plan) {
     println!();
     println!("{}", style("dfxvm is installed now.").bold());
     println!();
-    println!("The installation process doesn't yet update profile scripts");
-    println!("to add the dfxvm bin directory to your $PATH.");
+    if plan.options.modify_path {
+        post_install_msg_unix_modify_path(plan);
+    } else {
+        post_install_msg_unix_no_modify_path(plan);
+    }
+}
+
+pub fn post_install_msg_unix_modify_path(plan: &Plan) {
+    println!("To get started you may need to restart your current shell.");
+    println!("This would reload your PATH environment variable to include");
+    println!("the dfxvm bin directory.");
     println!();
+    post_install_msg_unix_configure_shell(plan);
+}
+
+pub fn post_install_msg_unix_no_modify_path(plan: &Plan) {
+    println!("To get started you need the dfxvm bin directory in your PATH:");
+    println!("  {}", style(&plan.bin_dir.display()).bold());
+    println!("This has not been done automatically.");
+    println!();
+    post_install_msg_unix_configure_shell(plan);
+}
+
+pub fn post_install_msg_unix_configure_shell(plan: &Plan) {
     println!("To configure your shell, run:");
     println!(r#"  source "{}""#, plan.env_path_user_facing);
     println!();

--- a/src/error/dfxvm_init.rs
+++ b/src/error/dfxvm_init.rs
@@ -1,7 +1,7 @@
 use crate::error::{
     dfxvm,
     env::NoHomeDirectoryError,
-    fs::{CreateDirAllError, WriteFileError},
+    fs::{AppendToFileError, CreateDirAllError, ReadToStringError, WriteFileError},
     installation::InstallBinariesError,
 };
 use thiserror::Error;
@@ -33,6 +33,9 @@ pub enum ExecutePlanError {
     Update(#[from] dfxvm::UpdateError),
 
     #[error(transparent)]
+    UpdateProfileScripts(#[from] UpdateProfileScriptsError),
+
+    #[error(transparent)]
     WriteFile(#[from] WriteFileError),
 }
 
@@ -41,4 +44,13 @@ pub enum ExecutePlanError {
 pub struct InteractError {
     #[from]
     source: dialoguer::Error,
+}
+
+#[derive(Error, Debug)]
+pub enum UpdateProfileScriptsError {
+    #[error(transparent)]
+    AppendToFile(#[from] AppendToFileError),
+
+    #[error(transparent)]
+    ReadProfileScript(#[from] ReadToStringError),
 }

--- a/src/error/fs.rs
+++ b/src/error/fs.rs
@@ -2,6 +2,18 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+pub enum AppendToFileError {
+    #[error(transparent)]
+    Open(#[from] OpenFileError),
+
+    #[error(transparent)]
+    Write(#[from] WriteFileError),
+
+    #[error(transparent)]
+    Sync(#[from] SyncDataError),
+}
+
+#[derive(Error, Debug)]
 #[error("failed to canonicalize '{path}'")]
 pub struct CanonicalizePathError {
     pub path: PathBuf,
@@ -83,6 +95,13 @@ pub struct RenameError {
 #[derive(Error, Debug)]
 #[error("failed to set permissions for {path}")]
 pub struct SetPermissionsError {
+    pub path: PathBuf,
+    pub source: std::io::Error,
+}
+
+#[derive(Error, Debug)]
+#[error("failed to sync data for {path}")]
+pub struct SyncDataError {
     pub path: PathBuf,
     pub source: std::io::Error,
 }

--- a/src/installation.rs
+++ b/src/installation.rs
@@ -2,6 +2,10 @@
 mod bin;
 mod dirs;
 mod env;
+mod profile;
+mod shell;
 
 pub use bin::install_binaries;
 pub use env::{env_file_contents, get_env_path_user_facing};
+pub use profile::ProfileScript;
+pub use shell::get_detected_profile_scripts;

--- a/src/installation/profile.rs
+++ b/src/installation/profile.rs
@@ -1,0 +1,31 @@
+use crate::installation::{get_env_path_user_facing, profile::ProfileScriptType::Posix};
+use std::path::PathBuf;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProfileScriptType {
+    Posix,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProfileScript {
+    pub path: PathBuf,
+    pub script_type: ProfileScriptType,
+}
+
+impl ProfileScript {
+    pub fn posix(path: PathBuf) -> Self {
+        Self {
+            path,
+            script_type: Posix,
+        }
+    }
+
+    pub fn source_string(&self) -> String {
+        // see https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#dot
+        format!(r#". "{}""#, get_env_path_user_facing())
+    }
+
+    pub fn is_file(&self) -> bool {
+        self.path.is_file()
+    }
+}

--- a/src/installation/shell.rs
+++ b/src/installation/shell.rs
@@ -1,0 +1,143 @@
+use crate::env::home_dir;
+use crate::installation::profile::ProfileScript;
+use std::path::PathBuf;
+use std::process::Command;
+
+// Most of this is copied/derived/modified from
+// https://github.com/rust-lang/rustup/blob/master/src/cli/self_update/shell.rs
+
+pub(crate) type Shell = Box<dyn UnixShell>;
+
+fn enumerate_shells() -> Vec<Shell> {
+    vec![Box::new(Posix), Box::new(Bash), Box::new(Zsh)]
+}
+
+fn get_available_shells() -> impl Iterator<Item = Shell> {
+    enumerate_shells().into_iter().filter(|sh| sh.does_exist())
+}
+pub fn get_detected_profile_scripts() -> Vec<ProfileScript> {
+    get_available_shells()
+        .flat_map(|sh| sh.update_rcs())
+        .collect()
+}
+
+pub(crate) trait UnixShell {
+    // Detects if a shell "exists". Users have multiple shells, so an "eager"
+    // heuristic should be used, assuming shells exist if any traces do.
+    fn does_exist(&self) -> bool;
+
+    // Gives all rcfiles of a given shell that dfxvm is concerned with.
+    // Used primarily in checking rcfiles for cleanup.
+    fn rcfiles(&self) -> Vec<ProfileScript>;
+
+    // Gives rcs that should be written to.
+    fn update_rcs(&self) -> Vec<ProfileScript>;
+}
+
+struct Posix;
+impl UnixShell for Posix {
+    fn does_exist(&self) -> bool {
+        true
+    }
+
+    fn rcfiles(&self) -> Vec<ProfileScript> {
+        match home_dir() {
+            Ok(dir) => vec![ProfileScript::posix(dir.join(".profile"))],
+            _ => vec![],
+        }
+    }
+
+    fn update_rcs(&self) -> Vec<ProfileScript> {
+        // Write to .profile even if it doesn't exist. It's the only rc in the
+        // POSIX spec so it should always be set up.
+        self.rcfiles()
+    }
+}
+
+struct Bash;
+
+impl UnixShell for Bash {
+    fn does_exist(&self) -> bool {
+        !self.update_rcs().is_empty()
+    }
+
+    fn rcfiles(&self) -> Vec<ProfileScript> {
+        let home = home_dir().ok();
+        // Bash also may read .profile, however UnixShell for Posix already handles this
+        [".bash_profile", ".bash_login", ".bashrc"]
+            .iter()
+            .filter_map(|rc| home.clone().map(|dir| dir.join(rc)))
+            .map(ProfileScript::posix)
+            .collect()
+    }
+
+    fn update_rcs(&self) -> Vec<ProfileScript> {
+        self.rcfiles()
+            .into_iter()
+            .filter(|rc| rc.is_file())
+            .collect()
+    }
+}
+
+struct Zsh;
+
+impl Zsh {
+    fn zdotdir() -> Option<PathBuf> {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        if matches!(std::env::var("SHELL"), Ok(sh) if sh.contains("zsh")) {
+            match std::env::var_os("ZDOTDIR") {
+                Some(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
+                _ => None,
+            }
+        } else {
+            match Command::new("zsh")
+                .args(["-c", "echo -n $ZDOTDIR"])
+                .output()
+            {
+                Ok(io) if !io.stdout.is_empty() => {
+                    Some(PathBuf::from(OsStr::from_bytes(&io.stdout)))
+                }
+                _ => None,
+            }
+        }
+    }
+}
+
+impl UnixShell for Zsh {
+    fn does_exist(&self) -> bool {
+        // zsh has to either be the shell or be callable for zsh setup.
+        matches!(std::env::var("SHELL"), Ok(sh) if sh.contains("zsh")) || find_cmd("zsh")
+    }
+
+    fn rcfiles(&self) -> Vec<ProfileScript> {
+        [Zsh::zdotdir(), home_dir().ok()]
+            .iter()
+            .filter_map(|dir| dir.as_ref().map(|p| p.join(".zshenv")))
+            .map(ProfileScript::posix)
+            .collect()
+    }
+
+    fn update_rcs(&self) -> Vec<ProfileScript> {
+        // zsh can change $ZDOTDIR both _before_ AND _during_ reading .zshenv,
+        // so we: write to $ZDOTDIR/.zshenv if-exists ($ZDOTDIR changes before)
+        // OR write to $HOME/.zshenv if it exists (change-during)
+        // if neither exist, we create one of them ourselves:
+        //    - $ZDOTDIR/.zshenv if $ZDOTDIR is set
+        //    - $HOME/.zshenv otherwise
+        self.rcfiles()
+            .into_iter()
+            .filter(|env| env.is_file())
+            .chain(self.rcfiles())
+            .take(1)
+            .collect()
+    }
+}
+
+fn find_cmd(cmd: &str) -> bool {
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(cmd))
+        .any(|p| p.exists())
+}

--- a/tests/suite/common/release_server.rs
+++ b/tests/suite/common/release_server.rs
@@ -1,3 +1,4 @@
+use crate::common::file_contents::manifest_json;
 use crate::common::{ReleaseAsset, TempHomeDir};
 use httptest::http::response;
 use httptest::{matchers::request, responders::status_code, Expectation, Server};
@@ -43,6 +44,14 @@ impl ReleaseServer {
                     .unwrap(),
             ),
         );
+    }
+
+    pub fn expect_install_latest(&self) {
+        let tarball = ReleaseAsset::dfx_tarball("0.15.0", "echo 'this is dfx 0.15.0'");
+        let sha256 = ReleaseAsset::sha256(&tarball);
+        self.expect_get(&tarball);
+        self.expect_get(&sha256);
+        self.expect_get_manifest(&manifest_json("0.15.0"));
     }
 }
 

--- a/tests/suite/common/temp_home_dir.rs
+++ b/tests/suite/common/temp_home_dir.rs
@@ -6,6 +6,7 @@ use crate::common::{
     project_dirs, Settings,
 };
 use std::cell::Cell;
+use std::ffi::OsStr;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -42,6 +43,10 @@ impl TempHomeDir {
         self.tempdir.path()
     }
 
+    pub fn join<P: AsRef<Path>>(&self, path: P) -> PathBuf {
+        self.path().join(path.as_ref())
+    }
+
     pub fn dfx(&self) -> Command {
         self.dfxvm_as_command_named("dfx")
     }
@@ -54,8 +59,8 @@ impl TempHomeDir {
         self.dfxvm_as_command_named("dfxvm-init")
     }
 
-    pub fn new_command(&self, program: &Path) -> Command {
-        let mut command = Command::new(program);
+    pub fn new_command<S: AsRef<OsStr>>(&self, program: S) -> Command {
+        let mut command = Command::new(program.as_ref());
 
         command.env_clear();
         command.env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
@@ -78,7 +83,7 @@ impl TempHomeDir {
 
     pub fn dfxvm_as_command_named(&self, filename: &str) -> Command {
         let path = self.dfxvm_as_file_named(filename);
-        self.new_command(&path)
+        self.new_command(path)
     }
 
     pub fn config_dir(&self) -> PathBuf {


### PR DESCRIPTION
# Description

dfxvm-init now updates profile scripts for posix (.profile), bash, and zsh to add the dfxvm bin directory to the PATH.

Fixes https://dfinity.atlassian.net/browse/SDK-1275

# How Has This Been Tested?

Added tests and tested locally.

# Checklist:

- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation in docs/cli-reference.
