### PR TITLE
refactor: construct Locations in one place

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use crate::error::cli::DetermineModeError::{NoExeName, UnrecognizedExeName};
 use crate::error::cli::{DetermineModeError, DispatchError};
+use crate::locations::Locations;
 use crate::log::log_error;
 use crate::{dfx, dfxvm, dfxvm_init};
 use std::ffi::OsString;
@@ -15,10 +16,11 @@ pub async fn main(args: &[OsString]) -> ExitCode {
 }
 
 pub async fn dispatch(args: &[OsString]) -> Result<ExitCode, DispatchError> {
+    let locations = Locations::new()?;
     let exit_code = match determine_mode(args)? {
-        Init => dfxvm_init::main(args).await?,
-        Manage => dfxvm::main(args).await?,
-        Proxy => dfx::main(args)?,
+        Init => dfxvm_init::main(args, &locations).await?,
+        Manage => dfxvm::main(args, &locations).await?,
+        Proxy => dfx::main(args, &locations)?,
     };
     Ok(exit_code)
 }

--- a/src/dfx.rs
+++ b/src/dfx.rs
@@ -17,10 +17,8 @@ use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-pub fn main(args: &[OsString]) -> Result<ExitCode, dfx::Error> {
-    let locations = Locations::new()?;
-
-    let Some((version, args)) = get_dfx_version_and_command_args(args, &locations)? else {
+pub fn main(args: &[OsString], locations: &Locations) -> Result<ExitCode, dfx::Error> {
+    let Some((version, args)) = get_dfx_version_and_command_args(args, locations)? else {
         err!("Unable to determine which dfx version to call. To set a default version, run:");
         err!("    {}", style_command("dfxvm default <version>"));
         return Ok(ExitCode::FAILURE);

--- a/src/dfxvm/cli.rs
+++ b/src/dfxvm/cli.rs
@@ -3,6 +3,7 @@ use crate::dfxvm::{
     self_update::self_update, uninstall::uninstall, update::update,
 };
 use crate::error::dfxvm;
+use crate::locations::Locations;
 use clap::{Parser, Subcommand};
 use semver::Version;
 use std::ffi::OsString;
@@ -78,18 +79,18 @@ pub struct SelfUpdateOpts {}
 #[derive(Parser)]
 pub struct SelfUninstallOpts {}
 
-pub async fn main(args: &[OsString]) -> Result<ExitCode, dfxvm::Error> {
+pub async fn main(args: &[OsString], locations: &Locations) -> Result<ExitCode, dfxvm::Error> {
     let cli = Cli::parse_from(args);
     match cli.command {
-        Command::Default(opts) => default(opts.version).await?,
-        Command::Install(opts) => install(opts.version).await?,
-        Command::List(_opts) => list()?,
+        Command::Default(opts) => default(opts.version, locations).await?,
+        Command::Install(opts) => install(opts.version, locations).await?,
+        Command::List(_opts) => list(locations)?,
         Command::SelfCommand(opts) => match opts.command {
-            SelfCommand::Update(_opts) => self_update()?,
-            SelfCommand::Uninstall(_opts) => self_uninstall()?,
+            SelfCommand::Update(_opts) => self_update(locations)?,
+            SelfCommand::Uninstall(_opts) => self_uninstall(locations)?,
         },
-        Command::Uninstall(opts) => uninstall(opts.version)?,
-        Command::Update(_opts) => update().await?,
+        Command::Uninstall(opts) => uninstall(opts.version, locations)?,
+        Command::Update(_opts) => update(locations).await?,
     };
     Ok(ExitCode::SUCCESS)
 }

--- a/src/dfxvm/default.rs
+++ b/src/dfxvm/default.rs
@@ -7,12 +7,11 @@ use crate::locations::Locations;
 use crate::settings::Settings;
 use semver::Version;
 
-pub async fn default(version: Option<Version>) -> Result<(), DefaultError> {
-    let locations = Locations::new()?;
+pub async fn default(version: Option<Version>, locations: &Locations) -> Result<(), DefaultError> {
     if let Some(version) = version {
-        set_default(&version, &locations).await?;
+        set_default(&version, locations).await?;
     } else {
-        display_default(&locations)?;
+        display_default(locations)?;
     }
     Ok(())
 }
@@ -21,7 +20,7 @@ pub async fn set_default(version: &Version, locations: &Locations) -> Result<(),
     if installed(version, locations) {
         info!("using existing install for dfx {version}");
     } else {
-        install(version.clone()).await?;
+        install(version.clone(), locations).await?;
     }
 
     let path = locations.settings_path();

--- a/src/dfxvm/install.rs
+++ b/src/dfxvm/install.rs
@@ -26,11 +26,10 @@ pub fn installed(version: &Version, locations: &Locations) -> bool {
     locations.version_dir(version).exists()
 }
 
-pub async fn install(version: Version) -> Result<(), InstallError> {
-    let locations = Locations::new()?;
+pub async fn install(version: Version, locations: &Locations) -> Result<(), InstallError> {
     let settings = Settings::load_or_default(&locations.settings_path())?;
     let version_dir = locations.version_dir(&version);
-    if installed(&version, &locations) {
+    if installed(&version, locations) {
         info!("dfx {version} is already installed");
         return Ok(());
     }

--- a/src/dfxvm/list.rs
+++ b/src/dfxvm/list.rs
@@ -4,12 +4,11 @@ use crate::settings::Settings;
 use itertools::Itertools;
 use semver::Version;
 
-pub fn list() -> Result<(), ListError> {
-    let locations = Locations::new()?;
+pub fn list(locations: &Locations) -> Result<(), ListError> {
     let settings = Settings::load_or_default(&locations.settings_path())?;
     let default_version = settings.default_version;
 
-    for version in installed_versions(&locations)? {
+    for version in installed_versions(locations)? {
         let default_indicator = if default_version.as_ref() == Some(&version) {
             " (default)"
         } else {

--- a/src/dfxvm/self_uninstall.rs
+++ b/src/dfxvm/self_uninstall.rs
@@ -1,6 +1,7 @@
 use crate::error::dfxvm::SelfUninstallError;
+use crate::locations::Locations;
 
-pub fn self_uninstall() -> Result<(), SelfUninstallError> {
+pub fn self_uninstall(_locations: &Locations) -> Result<(), SelfUninstallError> {
     println!("uninstall dfxvm and all dfx versions");
     Ok(())
 }

--- a/src/dfxvm/self_update.rs
+++ b/src/dfxvm/self_update.rs
@@ -1,6 +1,7 @@
 use crate::error::dfxvm::SelfUpdateError;
+use crate::locations::Locations;
 
-pub fn self_update() -> Result<(), SelfUpdateError> {
+pub fn self_update(_locations: &Locations) -> Result<(), SelfUpdateError> {
     println!("update dfxvm to latest");
     Ok(())
 }

--- a/src/dfxvm/uninstall.rs
+++ b/src/dfxvm/uninstall.rs
@@ -4,10 +4,9 @@ use crate::fs::{remove_dir_all, remove_file, rename};
 use crate::locations::Locations;
 use semver::Version;
 
-pub fn uninstall(version: Version) -> Result<(), UninstallError> {
-    let locations = Locations::new()?;
+pub fn uninstall(version: Version, locations: &Locations) -> Result<(), UninstallError> {
     let version_dir = locations.version_dir(&version);
-    if !installed(&version, &locations) {
+    if !installed(&version, locations) {
         info!("dfx {} is not installed", version);
         return Ok(());
     }

--- a/src/dfxvm/update.rs
+++ b/src/dfxvm/update.rs
@@ -7,8 +7,7 @@ use reqwest::Url;
 use semver::Version;
 use serde::Deserialize;
 
-pub async fn update() -> Result<(), UpdateError> {
-    let locations = Locations::new()?;
+pub async fn update(locations: &Locations) -> Result<(), UpdateError> {
     let settings = Settings::load_or_default(&locations.settings_path())?;
     let url = Url::parse(&settings.manifest_url())?;
 
@@ -18,7 +17,7 @@ pub async fn update() -> Result<(), UpdateError> {
     let latest_version = manifest.tags.latest;
     info!("latest dfx version is {latest_version}");
 
-    set_default(&latest_version, &locations).await?;
+    set_default(&latest_version, locations).await?;
 
     Ok(())
 }

--- a/src/dfxvm_init/cli.rs
+++ b/src/dfxvm_init/cli.rs
@@ -5,6 +5,7 @@ use crate::dfxvm_init::plan::{
 };
 use crate::dfxvm_init::ui::Confirmation;
 use crate::error::dfxvm_init;
+use crate::locations::Locations;
 use clap::Parser;
 use semver::Version;
 use std::ffi::OsString;
@@ -27,7 +28,7 @@ pub struct Cli {
     no_modify_path: bool,
 }
 
-pub async fn main(args: &[OsString]) -> Result<ExitCode, dfxvm_init::Error> {
+pub async fn main(args: &[OsString], locations: &Locations) -> Result<ExitCode, dfxvm_init::Error> {
     let opts = Cli::parse_from(args);
 
     let confirmation = if opts.proceed {
@@ -42,7 +43,7 @@ pub async fn main(args: &[OsString]) -> Result<ExitCode, dfxvm_init::Error> {
         .with_dfx_version(dfx_version)
         .with_modify_path(!opts.no_modify_path);
 
-    initialize(options, confirmation).await?;
+    initialize(options, confirmation, locations).await?;
 
     Ok(ExitCode::SUCCESS)
 }

--- a/src/dfxvm_init/initialize.rs
+++ b/src/dfxvm_init/initialize.rs
@@ -17,9 +17,9 @@ use std::path::Path;
 pub async fn initialize(
     options: PlanOptions,
     confirmation: Option<Confirmation>,
+    locations: &Locations,
 ) -> Result<(), dfxvm_init::Error> {
-    let locations = Locations::new()?;
-    let mut plan = Plan::new(options, &locations);
+    let mut plan = Plan::new(options, locations);
 
     ui::display::introduction(&plan);
 
@@ -38,7 +38,7 @@ pub async fn initialize(
         return Ok(());
     };
 
-    execute(&plan, &locations).await?;
+    execute(&plan, locations).await?;
 
     ui::display::success(&plan);
 
@@ -53,7 +53,7 @@ pub async fn execute(plan: &Plan, locations: &Locations) -> Result<(), ExecutePl
     install_binaries(&plan.bin_dir)?;
 
     match &plan.options.dfx_version {
-        DfxVersion::Latest => dfxvm::update().await?,
+        DfxVersion::Latest => dfxvm::update(locations).await?,
         DfxVersion::Specific(version) => dfxvm::set_default(version, locations).await?,
     }
 

--- a/src/error/cli.rs
+++ b/src/error/cli.rs
@@ -1,5 +1,4 @@
-use crate::error::dfxvm;
-use crate::error::{dfx, dfxvm_init};
+use crate::error::{dfx, dfxvm, dfxvm_init, env::NoHomeDirectoryError};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -12,6 +11,9 @@ pub enum DispatchError {
 
     #[error(transparent)]
     Manage(#[from] dfxvm::Error),
+
+    #[error(transparent)]
+    NoHomeDirectory(#[from] NoHomeDirectoryError),
 
     #[error(transparent)]
     Proxy(#[from] dfx::Error),

--- a/src/error/dfx.rs
+++ b/src/error/dfx.rs
@@ -1,6 +1,4 @@
-use crate::error::env::{GetCurrentDirError, NoHomeDirectoryError};
-use crate::error::fs::CanonicalizePathError;
-use crate::error::json::LoadJsonFileError;
+use crate::error::{env::GetCurrentDirError, fs::CanonicalizePathError, json::LoadJsonFileError};
 use std::process::Command;
 use thiserror::Error;
 
@@ -14,9 +12,6 @@ pub enum Error {
         command: Command,
         source: std::io::Error,
     },
-
-    #[error(transparent)]
-    NoHomeDirectory(#[from] NoHomeDirectoryError),
 }
 
 #[derive(Error, Debug)]

--- a/src/error/dfxvm.rs
+++ b/src/error/dfxvm.rs
@@ -1,5 +1,4 @@
 use crate::error::{
-    env::NoHomeDirectoryError,
     fs::{RemoveDirAllError, RemoveFileError, RenameError},
     json::{FetchJsonDocError, LoadJsonFileError},
 };
@@ -42,9 +41,6 @@ pub enum ListError {
     #[error(transparent)]
     LoadJsonFile(#[from] LoadJsonFileError),
 
-    #[error(transparent)]
-    NoHomeDirectory(#[from] NoHomeDirectoryError),
-
     #[error("failed to read directory {path}")]
     ReadDir {
         path: PathBuf,
@@ -54,9 +50,6 @@ pub enum ListError {
 
 #[derive(Error, Debug)]
 pub enum UninstallError {
-    #[error(transparent)]
-    NoHomeDirectory(#[from] NoHomeDirectoryError),
-
     #[error(transparent)]
     RemoveDirAll(#[from] RemoveDirAllError),
 
@@ -74,9 +67,6 @@ pub enum UpdateError {
 
     #[error(transparent)]
     LoadSettings(#[from] LoadJsonFileError),
-
-    #[error(transparent)]
-    NoHomeDirectory(#[from] NoHomeDirectoryError),
 
     #[error("failed to parse manifest url")]
     ParseManifestUrl(#[from] url::ParseError),

--- a/src/error/dfxvm/default.rs
+++ b/src/error/dfxvm/default.rs
@@ -1,6 +1,5 @@
 use crate::error::{
     dfxvm::install::InstallError,
-    env::NoHomeDirectoryError,
     fs::CreateDirAllError,
     json::{LoadJsonFileError, SaveJsonFileError},
 };
@@ -10,9 +9,6 @@ use thiserror::Error;
 pub enum DefaultError {
     #[error(transparent)]
     Display(#[from] DisplayDefaultError),
-
-    #[error(transparent)]
-    NoHomeDirectory(#[from] NoHomeDirectoryError),
 
     #[error(transparent)]
     Set(#[from] SetDefaultError),

--- a/src/error/dfxvm/install.rs
+++ b/src/error/dfxvm/install.rs
@@ -1,6 +1,5 @@
 use crate::error::{
     download::DownloadVerifiedTarballError,
-    env::NoHomeDirectoryError,
     fs::{CreateDirAllError, OpenFileError, RenameError},
     json::LoadJsonFileError,
 };
@@ -32,9 +31,6 @@ pub enum InstallError {
 
     #[error(transparent)]
     LoadSettings(#[from] LoadJsonFileError),
-
-    #[error(transparent)]
-    NoHomeDirectory(#[from] NoHomeDirectoryError),
 }
 
 #[derive(Error, Debug)]

--- a/src/error/dfxvm_init.rs
+++ b/src/error/dfxvm_init.rs
@@ -1,6 +1,5 @@
 use crate::error::{
     dfxvm,
-    env::NoHomeDirectoryError,
     fs::{AppendToFileError, CreateDirAllError, ReadToStringError, WriteFileError},
     installation::InstallBinariesError,
 };
@@ -13,9 +12,6 @@ pub enum Error {
 
     #[error(transparent)]
     Interact(#[from] InteractError),
-
-    #[error(transparent)]
-    NoHomeDirectory(#[from] NoHomeDirectoryError),
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
# Description

All of the dfxvm commands need the `Locations` object.  `self update` needs it a little higher in the call stack, in order to delete a binary.

This PR makes it so there is only one place that calls `Locations::new()`, and it's higher in the call stack.  This also means there are fewer places that can return `NoHomeDirectory` as an error.

# How Has This Been Tested?

Covered by CI