### PR TITLE
fix: make audit:required status name consistent with others

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   test:
-    name: required:audit
+    name: audit:required
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
This should have been `audit:required` to match the other required statuses like `fmt:required` and `test:required`

