### PR TITLE
chore: update to actions/cache@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
# Description

This is to fix this audit warning seen at https://github.com/dfinity/dfxvm/actions/runs/7697288174:
>    Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

# How Has This Been Tested?



# Checklist:

- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation in docs/cli-reference.
