### PR TITLE
feat: self uninstall

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ens/sdk-1273-self-uninstall
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ens/sdk-1273-self-uninstall
   pull_request:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 - Removed openssl dependencies
-- Added `dfxvm self uninstall` command, which uninstalls dfxvma and all versions of dfx.
+- Added `dfxvm self uninstall` command, which uninstalls dfxvm and all versions of dfx.
 
 ## [0.2.0] - 2024-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
-- removed openssl dependencies
+- Removed openssl dependencies
+- Added `dfxvm self uninstall` command, which uninstalls dfxvma and all versions of dfx.
 
 ## [0.2.0] - 2024-01-30
 
 - `dfxvm --version` now reports the version
-- changed the dfxvm-init `--proceed` parameter to `--yes`
-- static link to openssl
+- Changed the dfxvm-init `--proceed` parameter to `--yes`
+- Static link to openssl
 
 ## [0.1.3] - 2024-01-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
 
 [[package]]
 name = "anstyle-parse"
@@ -303,6 +303,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +360,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sysinfo",
  "tar",
  "tempfile",
  "thiserror",
@@ -877,6 +897,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1051,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1310,6 +1359,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.30.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb4f3438c8f6389c864e61221cbc97e9bca98b4daf39a5beb7bea660f528bb2"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
 ]
 
 [[package]]
@@ -1661,6 +1725,47 @@ name = "webpki-roots"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ semver = { version = "1.0", features = [ "serde" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 sha2 = "0.10.8"
+sysinfo = "0.30.5"
 tar = "0.4.40"
 tempfile = "3"
 thiserror = "1.0"

--- a/docs/cli-reference/dfxvm/dfxvm-self-uninstall.md
+++ b/docs/cli-reference/dfxvm/dfxvm-self-uninstall.md
@@ -1,3 +1,23 @@
 # dfxvm self uninstall
 
 Uninstalls dfxvm and all versions of dfx.
+
+## Usage
+
+```bash
+dfxvm self uninstall [--yes]
+```
+
+### Options
+
+| Option                    | Description |
+|---------------------------| --- |
+| `--yes`                   | Skip confirmation prompt |
+
+## Examples
+
+Uninstall dfxvm and all versions of dfx, with an opportunity to confirm or cancel.
+
+```bash
+dfxvm self uninstall
+```

--- a/src/dfxvm/cli.rs
+++ b/src/dfxvm/cli.rs
@@ -77,7 +77,11 @@ pub struct SelfUpdateOpts {}
 
 /// Uninstall dfxvm and all versions of dfx
 #[derive(Parser)]
-pub struct SelfUninstallOpts {}
+pub struct SelfUninstallOpts {
+    /// Automatically confirm un-installation.
+    #[clap(long)]
+    yes: bool,
+}
 
 pub async fn main(args: &[OsString], locations: &Locations) -> Result<ExitCode, dfxvm::Error> {
     cleanup_self_updater(locations)?;
@@ -88,7 +92,7 @@ pub async fn main(args: &[OsString], locations: &Locations) -> Result<ExitCode, 
         Command::List(_opts) => list(locations)?,
         Command::SelfCmd(opts) => match opts.command {
             SelfCommand::Update(_opts) => self_update(locations).await?,
-            SelfCommand::Uninstall(_opts) => self_uninstall(locations)?,
+            SelfCommand::Uninstall(opts) => self_uninstall(opts.yes, locations)?,
         },
         Command::Uninstall(opts) => uninstall(opts.version, locations)?,
         Command::Update(_opts) => update(locations).await?,

--- a/src/dfxvm/self_uninstall.rs
+++ b/src/dfxvm/self_uninstall.rs
@@ -1,7 +1,120 @@
-use crate::error::dfxvm::SelfUninstallError;
+use crate::error::{
+    dfxvm::{self_uninstall::UninstallProfileScriptsError, SelfUninstallError},
+    dfxvm_init::InteractError,
+    fs::{RemoveDirAllError, RemoveFileError},
+};
+use crate::fs::{read, remove_dir_all, remove_file, write};
+use crate::installation::get_all_profile_scripts;
 use crate::locations::Locations;
+use console::style;
+use dialoguer::Confirm;
+use std::path::Path;
+use sysinfo::System;
 
-pub fn self_uninstall(_locations: &Locations) -> Result<(), SelfUninstallError> {
-    println!("uninstall dfxvm and all dfx versions");
+pub fn self_uninstall(yes: bool, locations: &Locations) -> Result<(), SelfUninstallError> {
+    println!();
+    println!("Thanks for developing with dfx and dfxvm!");
+    println!();
+    println!("This will uninstall dfxvm and all dfx versions, and remove");
+    println!(
+        "{} from your PATH environment variable.",
+        style(locations.bin_dir().display()).bold()
+    );
+    println!();
+
+    if !yes && !confirm()? {
+        info!("canceling uninstallation");
+        return Ok(());
+    }
+
+    killall_dfx(locations);
+    delete_dir(&locations.network_dir())?;
+    delete_dir(locations.dfx_cache_dir())?;
+    delete_dir(locations.versions_dir())?;
+    delete_file(&locations.dfx_proxy_path())?;
+    uninstall_from_profile_scripts()?;
+    delete_file(&locations.env_path())?;
+    delete_own_binary(locations)?;
+    remove_dir_all(&locations.bin_dir())?;
+    remove_dir_all(locations.data_local_dir())?;
+
+    if locations.config_dir().exists() {
+        info!("did not delete the config directory because it may contain identities.");
+        info!("config directory: {}", locations.config_dir().display());
+    }
+
+    Ok(())
+}
+
+fn delete_own_binary(locations: &Locations) -> Result<(), RemoveFileError> {
+    delete_file(&locations.dfxvm_path())
+}
+
+fn uninstall_from_profile_scripts() -> Result<(), UninstallProfileScriptsError> {
+    for ps in get_all_profile_scripts() {
+        if ps.is_file() {
+            let source_bytes = ps.source_string().into_bytes();
+            let file_bytes = read(&ps.path)?;
+            // This approach copied from https://github.com/rust-lang/rustup/blob/master/src/cli/self_update/unix.rs#L56
+            if let Some(idx) = file_bytes
+                .windows(source_bytes.len())
+                .position(|w| w == source_bytes.as_slice())
+            {
+                // Here we rewrite the file without the offending line.
+                let mut new_bytes = file_bytes[..idx].to_vec();
+                new_bytes.extend(&file_bytes[idx + source_bytes.len()..]);
+                write(&ps.path, &new_bytes)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn killall_dfx(locations: &Locations) {
+    while killany_dfx(locations) {
+        continue;
+    }
+}
+
+fn killany_dfx(locations: &Locations) -> bool {
+    let versions_dir = locations.versions_dir();
+    let dfx_cache_dir = locations.dfx_cache_dir();
+
+    let mut info = System::new();
+    info.refresh_processes();
+    let mut n = 0;
+    for (pid, proc) in info.processes() {
+        if let Some(exe) = proc.exe() {
+            if exe.starts_with(versions_dir) || exe.starts_with(dfx_cache_dir) {
+                info!("killing {} {}", pid.as_u32(), exe.display());
+                n += 1;
+                proc.kill();
+            }
+        }
+    }
+    n > 0
+}
+
+fn confirm() -> Result<bool, InteractError> {
+    let uninstall = Confirm::new()
+        .with_prompt("Continue?")
+        .default(false)
+        .interact()?;
+    Ok(uninstall)
+}
+
+fn delete_dir(dir: &Path) -> Result<(), RemoveDirAllError> {
+    if dir.exists() {
+        info!("deleting {}", dir.display());
+        remove_dir_all(dir)?;
+    }
+    Ok(())
+}
+
+fn delete_file(path: &Path) -> Result<(), RemoveFileError> {
+    if path.exists() {
+        info!("deleting {}", path.display());
+        remove_file(path)?;
+    }
     Ok(())
 }

--- a/src/error/dfxvm.rs
+++ b/src/error/dfxvm.rs
@@ -8,11 +8,13 @@ use thiserror::Error;
 
 pub mod default;
 pub mod install;
+pub mod self_uninstall;
 pub mod self_update;
 
 pub use default::DefaultError;
 pub use default::SetDefaultError;
 pub use install::InstallError;
+pub use self_uninstall::SelfUninstallError;
 pub use self_update::SelfUpdateError;
 
 #[derive(Error, Debug)]
@@ -80,6 +82,3 @@ pub enum UpdateError {
     #[error(transparent)]
     SetDefault(#[from] SetDefaultError),
 }
-
-#[derive(Error, Debug)]
-pub enum SelfUninstallError {}

--- a/src/error/dfxvm/self_uninstall.rs
+++ b/src/error/dfxvm/self_uninstall.rs
@@ -1,0 +1,29 @@
+use crate::error::{
+    dfxvm_init::InteractError,
+    fs::{ReadFileError, RemoveDirAllError, RemoveFileError, WriteFileError},
+};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SelfUninstallError {
+    #[error(transparent)]
+    Interact(#[from] InteractError),
+
+    #[error(transparent)]
+    RemoveDirAll(#[from] RemoveDirAllError),
+
+    #[error(transparent)]
+    RemoveFile(#[from] RemoveFileError),
+
+    #[error(transparent)]
+    UninstallProfileScripts(#[from] UninstallProfileScriptsError),
+}
+
+#[derive(Error, Debug)]
+pub enum UninstallProfileScriptsError {
+    #[error(transparent)]
+    ReadFile(#[from] ReadFileError),
+
+    #[error(transparent)]
+    WriteFile(#[from] WriteFileError),
+}

--- a/src/installation.rs
+++ b/src/installation.rs
@@ -8,4 +8,4 @@ mod shell;
 pub use bin::install_binaries;
 pub use env::{env_file_contents, get_env_path_user_facing};
 pub use profile::ProfileScript;
-pub use shell::get_detected_profile_scripts;
+pub use shell::{get_all_profile_scripts, get_detected_profile_scripts};

--- a/src/installation/shell.rs
+++ b/src/installation/shell.rs
@@ -15,9 +15,17 @@ fn enumerate_shells() -> Vec<Shell> {
 fn get_available_shells() -> impl Iterator<Item = Shell> {
     enumerate_shells().into_iter().filter(|sh| sh.does_exist())
 }
+
 pub fn get_detected_profile_scripts() -> Vec<ProfileScript> {
     get_available_shells()
         .flat_map(|sh| sh.update_rcs())
+        .collect()
+}
+
+pub fn get_all_profile_scripts() -> Vec<ProfileScript> {
+    enumerate_shells()
+        .iter()
+        .flat_map(|sh| sh.rcfiles())
         .collect()
 }
 

--- a/src/locations.rs
+++ b/src/locations.rs
@@ -10,6 +10,7 @@ pub struct Locations {
     data_local_dir: PathBuf,
     versions_dir: PathBuf,
     config_dir: PathBuf,
+    dfx_cache_dir: PathBuf,
 }
 
 impl Locations {
@@ -39,8 +40,28 @@ impl Locations {
         self.data_local_dir.join("bin")
     }
 
+    pub fn dfx_proxy_path(&self) -> PathBuf {
+        self.bin_dir().join("dfx")
+    }
+
+    pub fn dfxvm_path(&self) -> PathBuf {
+        self.bin_dir().join("dfxvm")
+    }
+
     pub fn settings_path(&self) -> PathBuf {
         self.config_dir.join(SETTINGS_FILENAME)
+    }
+
+    pub fn env_path(&self) -> PathBuf {
+        self.data_local_dir.join("env")
+    }
+
+    pub fn network_dir(&self) -> PathBuf {
+        self.data_local_dir.join("network")
+    }
+
+    pub fn dfx_cache_dir(&self) -> &Path {
+        &self.dfx_cache_dir
     }
 }
 
@@ -52,10 +73,14 @@ impl Locations {
         let versions_dir = data_local_dir.join("versions");
         #[cfg(unix)]
         let config_dir = home_dir()?.join(".config").join("dfx");
+        #[cfg(unix)]
+        let dfx_cache_dir = home_dir()?.join(".cache").join("dfinity").join("versions");
+
         Ok(Self {
             data_local_dir,
             versions_dir,
             config_dir,
+            dfx_cache_dir,
         })
     }
 }

--- a/tests/suite/common/file_contents.rs
+++ b/tests/suite/common/file_contents.rs
@@ -6,10 +6,6 @@ use sha2::{Digest, Sha256};
 use std::io::Write;
 use tar::Builder;
 
-pub fn dfx_tar_gz(script: &str) -> Vec<u8> {
-    binary_tar_gz("dfx", script.as_bytes())
-}
-
 /// make a .tar.gz that looks like a dfx release tarball
 /// $ tar -tvf dfx-0.15.1-x86_64-darwin.tar.gz
 // -rwxr-xr-x  0 runner staff 128330472 Oct  5 00:45 dfx

--- a/tests/suite/common/release_asset.rs
+++ b/tests/suite/common/release_asset.rs
@@ -1,6 +1,6 @@
 use crate::common::{
     file_contents,
-    file_contents::{bash_script, dfx_tar_gz},
+    file_contents::{bash_script, binary_tar_gz},
     target,
 };
 use httptest::http::{response, Response};
@@ -15,13 +15,17 @@ pub struct ReleaseAsset {
 
 impl ReleaseAsset {
     pub fn dfx_tarball(version: &str, snippet: &str) -> ReleaseAsset {
+        Self::dfx_tarball_with_dfx_contents(version, bash_script(snippet).as_bytes())
+    }
+
+    pub fn dfx_tarball_with_dfx_contents(version: &str, executable: &[u8]) -> ReleaseAsset {
         let filename = Self::dfx_tarball_filename(version);
         let version = Version::parse(version).unwrap();
 
         // must match the download_url_template in ReleaseServer::new
         let url_path = format!("/any/arbitrary/path/{version}/{filename}");
 
-        let contents = dfx_tar_gz(&bash_script(snippet));
+        let contents = binary_tar_gz("dfx", executable);
         ReleaseAsset {
             url_path,
             filename,

--- a/tests/suite/common/temp_home_dir.rs
+++ b/tests/suite/common/temp_home_dir.rs
@@ -44,6 +44,10 @@ impl TempHomeDir {
         self.tempdir.path()
     }
 
+    pub fn dfx_cache_versions_dir(&self) -> PathBuf {
+        self.path().join(".cache").join("dfinity").join("versions")
+    }
+
     pub fn join<P: AsRef<Path>>(&self, path: P) -> PathBuf {
         self.path().join(path.as_ref())
     }
@@ -125,6 +129,10 @@ impl TempHomeDir {
         self.versions_dir().join(version)
     }
 
+    pub fn dfx_version_path(&self, version: &str) -> PathBuf {
+        self.dfx_version_dir(version).join("dfx")
+    }
+
     pub fn dfx_version_dirs(&self) -> Vec<String> {
         self.versions_dir()
             .read_dir()
@@ -147,12 +155,20 @@ impl TempHomeDir {
         self.dfx_version_dir(version).join("dfx")
     }
 
+    pub fn installed_bin_dir(&self) -> PathBuf {
+        self.data_local_dir().join("bin")
+    }
+
     pub fn installed_dfxvm_path(&self) -> PathBuf {
-        self.data_local_dir().join("bin").join("dfxvm")
+        self.installed_bin_dir().join("dfxvm")
     }
 
     pub fn installed_dfx_proxy_path(&self) -> PathBuf {
-        self.data_local_dir().join("bin").join("dfx")
+        self.installed_bin_dir().join("dfx")
+    }
+
+    pub fn installed_env_path(&self) -> PathBuf {
+        self.data_local_dir().join("env")
     }
 
     pub fn create_executable_dfx_script(&self, version: &str, snippet: &str) -> PathBuf {

--- a/tests/suite/dfxvm/self_uninstall.rs
+++ b/tests/suite/dfxvm/self_uninstall.rs
@@ -107,7 +107,7 @@ fn all_process_exe_paths() -> Vec<PathBuf> {
     info.refresh_processes();
     info.processes()
         .iter()
-        .map(|(_pid, proc)| proc.exe().unwrap().to_path_buf())
+        .filter_map(|(_pid, proc)| proc.exe().map(|p| p.to_path_buf()))
         .collect()
 }
 

--- a/tests/suite/dfxvm/self_uninstall.rs
+++ b/tests/suite/dfxvm/self_uninstall.rs
@@ -18,7 +18,7 @@ fn self_uninstall() {
     server.expect_get(&sha256);
     server.expect_get_manifest(&manifest_json("0.15.0"));
 
-    let all_rcs = [
+    let mut all_rcs = vec![
         ".zshenv",
         ".profile",
         ".bash_profile",
@@ -31,7 +31,12 @@ fn self_uninstall() {
         std::fs::write(&rc_path, FAKE_RC).unwrap();
     }
 
-    home_dir.dfxvm_init().arg("--yes").assert().success();
+    home_dir
+        .dfxvm_init()
+        .arg("--yes")
+        .env("SHELL", "zsh") // force .zshenv update
+        .assert()
+        .success();
 
     populate_dfx_cache_versions(&home_dir, &fake_dfx);
     populate_local_network_dir(&home_dir);

--- a/tests/suite/dfxvm/self_uninstall.rs
+++ b/tests/suite/dfxvm/self_uninstall.rs
@@ -50,7 +50,7 @@ fn self_uninstall() {
         let rc_path = home_dir.join(rc);
         let rc = std::fs::read_to_string(&rc_path).unwrap();
         let expected = FAKE_RC.to_owned() + &posix_source();
-        assert_eq!(rc, expected);
+        assert_eq!(rc, expected, "rc: {}", rc_path.display());
     }
     assert!(home_dir.dfx_cache_versions_dir().exists());
     assert!(all_process_exe_paths().contains(&home_dir.dfx_version_path("0.15.0")));

--- a/tests/suite/dfxvm/self_uninstall.rs
+++ b/tests/suite/dfxvm/self_uninstall.rs
@@ -18,7 +18,7 @@ fn self_uninstall() {
     server.expect_get(&sha256);
     server.expect_get_manifest(&manifest_json("0.15.0"));
 
-    let mut all_rcs = vec![
+    let all_rcs = [
         ".zshenv",
         ".profile",
         ".bash_profile",

--- a/tests/suite/dfxvm/self_uninstall.rs
+++ b/tests/suite/dfxvm/self_uninstall.rs
@@ -1,14 +1,144 @@
-use crate::common::TempHomeDir;
+use crate::common::file_contents::manifest_json;
+use crate::common::{ReleaseAsset, ReleaseServer, TempHomeDir};
+use crate::dfxvm_init::{posix_source, FAKE_RC};
 use assert_cmd::prelude::*;
+use std::path::PathBuf;
+use std::process::Command;
 
 #[test]
 fn self_uninstall() {
     let home_dir = TempHomeDir::new();
-    let mut cmd = home_dir.dfxvm();
-    cmd.arg("self");
-    cmd.arg("uninstall");
+    let server = ReleaseServer::new(&home_dir);
 
-    cmd.assert()
-        .success()
-        .stdout("uninstall dfxvm and all dfx versions\n");
+    let fake_dfx = looping_executable();
+
+    let tarball = ReleaseAsset::dfx_tarball_with_dfx_contents("0.15.0", &fake_dfx);
+    let sha256 = ReleaseAsset::sha256(&tarball);
+    server.expect_get(&tarball);
+    server.expect_get(&sha256);
+    server.expect_get_manifest(&manifest_json("0.15.0"));
+
+    let all_rcs = [
+        ".zshenv",
+        ".profile",
+        ".bash_profile",
+        ".bash_login",
+        ".bashrc",
+    ];
+
+    for rc in all_rcs {
+        let rc_path = home_dir.join(rc);
+        std::fs::write(&rc_path, FAKE_RC).unwrap();
+    }
+
+    home_dir.dfxvm_init().arg("--yes").assert().success();
+
+    populate_dfx_cache_versions(&home_dir, &fake_dfx);
+    populate_local_network_dir(&home_dir);
+
+    std::fs::write(home_dir.installed_bin_dir().join("junk"), "junk").unwrap();
+
+    let mut h = Command::new(home_dir.dfx_version_path("0.15.0"))
+        .spawn()
+        .unwrap();
+
+    assert!(home_dir.installed_dfxvm_path().exists());
+    assert!(home_dir.installed_dfx_proxy_path().exists());
+    assert!(home_dir.versions_dir().exists());
+    assert!(home_dir.installed_env_path().exists());
+    for rc in all_rcs {
+        let rc_path = home_dir.join(rc);
+        let rc = std::fs::read_to_string(&rc_path).unwrap();
+        let expected = FAKE_RC.to_owned() + &posix_source();
+        assert_eq!(rc, expected);
+    }
+    assert!(home_dir.dfx_cache_versions_dir().exists());
+    assert!(all_process_exe_paths().contains(&home_dir.dfx_version_path("0.15.0")));
+
+    home_dir
+        .installed_dfxvm()
+        .args(["self", "uninstall", "--yes"])
+        .assert()
+        .success();
+
+    // deletes bin/dfxvm
+    assert!(!home_dir.installed_dfxvm_path().exists());
+    assert!(!home_dir.installed_dfx_proxy_path().exists());
+    assert!(!home_dir.installed_bin_dir().exists());
+    assert!(!home_dir.versions_dir().exists());
+    assert!(!home_dir.installed_env_path().exists());
+    for rc in all_rcs {
+        let rc_path = home_dir.join(rc);
+        let rc = std::fs::read_to_string(&rc_path).unwrap();
+        let expected = FAKE_RC.to_owned() + "\n";
+        assert_eq!(rc, expected);
+    }
+    assert!(!home_dir.dfx_cache_versions_dir().exists());
+    assert!(!all_process_exe_paths().contains(&home_dir.dfx_version_path("0.15.0")));
+    assert!(!home_dir.data_local_dir().exists());
+
+    h.wait().unwrap();
+}
+
+fn populate_local_network_dir(temp_home_dir: &TempHomeDir) {
+    let dir = temp_home_dir.data_local_dir().join("network").join("local");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("webserver-port"), "7654").unwrap();
+}
+
+fn populate_dfx_cache_versions(home_dir: &TempHomeDir, fake_dfx: &[u8]) {
+    populate_dfx_cache_version("0.15.0", home_dir, fake_dfx);
+    populate_dfx_cache_version("0.14.4", home_dir, fake_dfx);
+}
+
+fn populate_dfx_cache_version(version: &str, home_dir: &TempHomeDir, fake_dfx: &[u8]) {
+    let dir = home_dir.dfx_cache_versions_dir().join(version);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("dfx"), fake_dfx).unwrap();
+}
+
+fn all_process_exe_paths() -> Vec<PathBuf> {
+    let mut info = sysinfo::System::new();
+    info.refresh_processes();
+    info.processes()
+        .iter()
+        .map(|(_pid, proc)| proc.exe().unwrap().to_path_buf())
+        .collect()
+}
+
+fn looping_executable() -> Vec<u8> {
+    let tempdir = tempfile::Builder::new()
+        .prefix("dfxvm-integration-tests-builder")
+        .tempdir()
+        .unwrap();
+
+    let cargo_toml = r#"
+[package]
+name = "loop"
+version = "0.1.0"
+edition = "2018"
+
+[[bin]]
+name = "loop"
+path = "main.rs"
+"#;
+    let main_rs = r#"
+fn main() {
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}
+"#;
+
+    std::fs::write(tempdir.path().join("Cargo.toml"), cargo_toml).unwrap();
+    std::fs::write(tempdir.path().join("main.rs"), main_rs).unwrap();
+
+    Command::new("cargo")
+        .arg("build")
+        .current_dir(tempdir.path())
+        .assert()
+        .success();
+
+    let path = tempdir.path().join("target").join("debug").join("loop");
+    std::fs::read(path).unwrap()
 }

--- a/tests/suite/dfxvm_init.rs
+++ b/tests/suite/dfxvm_init.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 // This fake rc copied from https://github.com/rust-lang/rustup/blob/master/tests/suite/cli_paths.rs
 // Let's write a fake .rc which looks vaguely like a real script.
-const FAKE_RC: &str = r#"
+pub const FAKE_RC: &str = r#"
 # Sources fruity punch.
 . ~/fruit/punch
 
@@ -14,7 +14,7 @@ const FAKE_RC: &str = r#"
 export PATH="$HOME/apple/bin"
 "#;
 
-fn posix_source() -> String {
+pub fn posix_source() -> String {
     #[cfg(target_os = "macos")]
     let env_path = "$HOME/Library/Application Support/org.dfinity.dfx/env";
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
# Description

Adds the `self uninstall` command.

Fixes https://dfinity.atlassian.net/browse/SDK-1273

Note to reviewers: the only thing I'm not super stoked about is the profile cleanup.  Specifically, it will find a line like `# . <data-local-dir>/env` and change it to `# `.  On the other hand, this is what rustup does, and I suppose it works well enough for them.  The same kind of thing comes up during install: A commented-out line in a profile script will cause dfxvm-init not to add the source command to the profile script.

# How Has This Been Tested?

Added a test

# Checklist:

- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation in docs/cli-reference.
