### PR TITLE
feat: clean up previous dfx installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
-- Removed openssl dependencies
+- Removed openssl dependencies.
 - Added `dfxvm self uninstall` command, which uninstalls dfxvm and all versions of dfx.
+- `dfxvm-init` now removes older dfx versions found on the path, by default.
+- `dfxvm-init` deletes the uninstall.sh script that the dfx install script used to create.
 
 ## [0.2.0] - 2024-01-30
 
-- `dfxvm --version` now reports the version
-- Changed the dfxvm-init `--proceed` parameter to `--yes`
-- Static link to openssl
+- `dfxvm --version` now reports the version.
+- Changed the dfxvm-init `--proceed` parameter to `--yes`.
+- Static link to openssl.
 
 ## [0.1.3] - 2024-01-19
 

--- a/src/dfxvm/self_uninstall.rs
+++ b/src/dfxvm/self_uninstall.rs
@@ -29,7 +29,7 @@ pub fn self_uninstall(yes: bool, locations: &Locations) -> Result<(), SelfUninst
 
     killall_dfx(locations);
     delete_dir(&locations.network_dir())?;
-    delete_dir(locations.dfx_cache_dir())?;
+    delete_dir(locations.dfinity_cache_dir())?;
     delete_dir(locations.versions_dir())?;
     delete_file(&locations.dfx_proxy_path())?;
     uninstall_from_profile_scripts()?;
@@ -78,14 +78,14 @@ fn killall_dfx(locations: &Locations) {
 
 fn killany_dfx(locations: &Locations) -> bool {
     let versions_dir = locations.versions_dir();
-    let dfx_cache_dir = locations.dfx_cache_dir();
+    let dfinity_cache_versions_dir = locations.dfinity_cache_versions_dir();
 
     let mut info = System::new();
     info.refresh_processes();
     let mut n = 0;
     for (pid, proc) in info.processes() {
         if let Some(exe) = proc.exe() {
-            if exe.starts_with(versions_dir) || exe.starts_with(dfx_cache_dir) {
+            if exe.starts_with(versions_dir) || exe.starts_with(&dfinity_cache_versions_dir) {
                 info!("killing {} {}", pid.as_u32(), exe.display());
                 n += 1;
                 proc.kill();

--- a/src/dfxvm_init/plan.rs
+++ b/src/dfxvm_init/plan.rs
@@ -1,7 +1,9 @@
+use crate::error::fs::CanonicalizePathError;
+use crate::fs::canonicalize;
 use crate::installation::{get_detected_profile_scripts, get_env_path_user_facing, ProfileScript};
 use crate::locations::Locations;
 use semver::Version;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Clone)]
 pub enum DfxVersion {
@@ -13,6 +15,7 @@ pub enum DfxVersion {
 pub struct PlanOptions {
     pub dfx_version: DfxVersion,
     pub modify_path: bool,
+    pub delete_dfx_on_path: bool,
 }
 
 impl PlanOptions {
@@ -20,6 +23,7 @@ impl PlanOptions {
         Self {
             dfx_version: DfxVersion::Latest,
             modify_path: true,
+            delete_dfx_on_path: true,
         }
     }
 
@@ -33,6 +37,13 @@ impl PlanOptions {
     pub fn with_modify_path(self, modify_path: bool) -> Self {
         Self {
             modify_path,
+            ..self
+        }
+    }
+
+    pub fn delete_dfx_on_path(self, delete_dfx_on_path: bool) -> Self {
+        Self {
+            delete_dfx_on_path,
             ..self
         }
     }
@@ -51,25 +62,50 @@ pub struct Plan {
     // altering profile scripts.
     pub env_path_user_facing: String,
 
+    pub dfx_on_path: Vec<PathBuf>,
     pub profile_scripts: Vec<ProfileScript>,
 }
 
 impl Plan {
-    pub fn new(options: PlanOptions, locations: &Locations) -> Self {
+    pub fn new(options: PlanOptions, locations: &Locations) -> Result<Self, CanonicalizePathError> {
         let bin_dir = locations.bin_dir();
         let env_path = locations.data_local_dir().join("env");
         let env_path_user_facing = get_env_path_user_facing().to_string();
         let profile_scripts = get_detected_profile_scripts();
-        Self {
+        let dfx_on_path = legacy_binaries(&locations.dfx_proxy_path())?;
+
+        Ok(Self {
             options,
             bin_dir,
             env_path,
             env_path_user_facing,
+            dfx_on_path,
             profile_scripts,
-        }
+        })
     }
 
     pub fn with_options(self, options: PlanOptions) -> Self {
         Self { options, ..self }
     }
+}
+
+// find dfx binaries on PATH, excluding the dfx proxy
+fn legacy_binaries(dfx_proxy: &Path) -> Result<Vec<PathBuf>, CanonicalizePathError> {
+    let all_dfx_on_path = std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
+        .filter_map(|dir| {
+            let dfx_on_path = dir.join("dfx");
+            dfx_on_path.exists().then(|| canonicalize(&dfx_on_path))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let legacy_binaries = if dfx_proxy.exists() {
+        let canonical_dfx_proxy = canonicalize(dfx_proxy)?;
+        all_dfx_on_path
+            .into_iter()
+            .filter(|p| *p != canonical_dfx_proxy)
+            .collect()
+    } else {
+        all_dfx_on_path
+    };
+    Ok(legacy_binaries)
 }

--- a/src/dfxvm_init/ui.rs
+++ b/src/dfxvm_init/ui.rs
@@ -1,7 +1,9 @@
 mod confirm;
 mod customize;
+mod deletion_strategy;
 pub mod display;
 
 pub use confirm::confirm;
 pub use confirm::Confirmation;
 pub use customize::customize;
+pub use deletion_strategy::{select_deletion_strategy, DeletionStrategy};

--- a/src/dfxvm_init/ui/customize.rs
+++ b/src/dfxvm_init/ui/customize.rs
@@ -14,6 +14,11 @@ pub fn customize(plan: Plan) -> Result<Plan, InteractError> {
     let dfx_version = select_dfx_version(&options.dfx_version)?;
     options = options.with_dfx_version(dfx_version);
 
+    if !plan.dfx_on_path.is_empty() {
+        let delete_dfx_on_path = delete_dfx_on_path(options.delete_dfx_on_path)?;
+        options = options.delete_dfx_on_path(delete_dfx_on_path);
+    }
+
     let modify_path = select_modify_path(options.modify_path)?;
     options = options.with_modify_path(modify_path);
 
@@ -47,6 +52,14 @@ fn select_dfx_version(install_dfx: &DfxVersion) -> Result<DfxVersion, InteractEr
         }
     };
     Ok(dfx_version)
+}
+
+fn delete_dfx_on_path(current: bool) -> Result<bool, InteractError> {
+    let modify = Confirm::new()
+        .with_prompt("Delete dfx binaries found on PATH?")
+        .default(current)
+        .interact()?;
+    Ok(modify)
 }
 
 fn select_modify_path(current: bool) -> Result<bool, InteractError> {

--- a/src/dfxvm_init/ui/deletion_strategy.rs
+++ b/src/dfxvm_init/ui/deletion_strategy.rs
@@ -1,0 +1,31 @@
+use crate::error::dfxvm_init::InteractError;
+use dialoguer::Select;
+
+pub enum DeletionStrategy {
+    Manual,
+    CallSudo,
+    DontDelete,
+}
+
+pub fn select_deletion_strategy() -> Result<DeletionStrategy, InteractError> {
+    let items = vec![
+        "I've deleted them manually (default)",
+        "Call sudo rm for me (I'll enter my password)",
+        "Don't delete anything. I'll do it later",
+    ];
+
+    let index = Select::new()
+        .with_prompt("How would you like to proceed?")
+        .default(0)
+        .items(&items)
+        .interact()?;
+
+    let deletion_strategy = match index {
+        0 => DeletionStrategy::Manual,
+        1 => DeletionStrategy::CallSudo,
+        2 => DeletionStrategy::DontDelete,
+        _ => unreachable!(),
+    };
+
+    Ok(deletion_strategy)
+}

--- a/src/error/dfxvm_init.rs
+++ b/src/error/dfxvm_init.rs
@@ -3,8 +3,7 @@ use crate::error::{
     dfxvm::self_update::SelfReplaceError,
     fs::{
         AppendToFileError, CanonicalizePathError, CreateDirAllError, ReadToStringError,
-        RemoveFileError,
-        WriteFileError,
+        RemoveFileError, WriteFileError,
     },
     installation::InstallBinariesError,
 };

--- a/src/error/dfxvm_init.rs
+++ b/src/error/dfxvm_init.rs
@@ -1,13 +1,20 @@
 use crate::error::{
     dfxvm,
     dfxvm::self_update::SelfReplaceError,
-    fs::{AppendToFileError, CreateDirAllError, ReadToStringError, WriteFileError},
+    fs::{
+        AppendToFileError, CanonicalizePathError, CreateDirAllError, ReadToStringError,
+        RemoveFileError,
+        WriteFileError,
+    },
     installation::InstallBinariesError,
 };
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
+    #[error(transparent)]
+    CanonicalizePath(#[from] CanonicalizePathError),
+
     #[error(transparent)]
     ExecutePlan(#[from] ExecutePlanError),
 
@@ -24,10 +31,16 @@ pub enum ExecutePlanError {
     CreateDirectories(#[from] CreateDirAllError),
 
     #[error(transparent)]
+    DeleteDfxOnPath(#[from] DeleteDfxOnPathError),
+
+    #[error(transparent)]
     SetDefault(#[from] dfxvm::SetDefaultError),
 
     #[error(transparent)]
     InstallBinaries(#[from] InstallBinariesError),
+
+    #[error(transparent)]
+    RemoveFile(#[from] RemoveFileError),
 
     #[error(transparent)]
     Update(#[from] dfxvm::UpdateError),
@@ -53,4 +66,13 @@ pub enum UpdateProfileScriptsError {
 
     #[error(transparent)]
     ReadProfileScript(#[from] ReadToStringError),
+}
+
+#[derive(Error, Debug)]
+pub enum DeleteDfxOnPathError {
+    #[error(transparent)]
+    Interact(#[from] InteractError),
+
+    #[error("failed to call sudo rm")]
+    CallSudoRm(#[from] std::io::Error),
 }

--- a/src/locations.rs
+++ b/src/locations.rs
@@ -10,7 +10,7 @@ pub struct Locations {
     data_local_dir: PathBuf,
     versions_dir: PathBuf,
     config_dir: PathBuf,
-    dfx_cache_dir: PathBuf,
+    dfinity_cache_dir: PathBuf,
 }
 
 impl Locations {
@@ -60,8 +60,12 @@ impl Locations {
         self.data_local_dir.join("network")
     }
 
-    pub fn dfx_cache_dir(&self) -> &Path {
-        &self.dfx_cache_dir
+    pub fn dfinity_cache_dir(&self) -> &Path {
+        &self.dfinity_cache_dir
+    }
+
+    pub fn dfinity_cache_versions_dir(&self) -> PathBuf {
+        self.dfinity_cache_dir.join("versions")
     }
 }
 
@@ -74,13 +78,13 @@ impl Locations {
         #[cfg(unix)]
         let config_dir = home_dir()?.join(".config").join("dfx");
         #[cfg(unix)]
-        let dfx_cache_dir = home_dir()?.join(".cache").join("dfinity").join("versions");
+        let dfinity_cache_dir = home_dir()?.join(".cache").join("dfinity");
 
         Ok(Self {
             data_local_dir,
             versions_dir,
             config_dir,
-            dfx_cache_dir,
+            dfinity_cache_dir,
         })
     }
 }

--- a/tests/suite/common/mod.rs
+++ b/tests/suite/common/mod.rs
@@ -1,5 +1,6 @@
 mod executable;
 pub mod file_contents;
+pub mod paths;
 pub mod project_dirs;
 mod release_asset;
 mod release_server;

--- a/tests/suite/common/paths.rs
+++ b/tests/suite/common/paths.rs
@@ -1,0 +1,19 @@
+use std::path::Path;
+
+#[cfg(unix)]
+pub const MINIMAL_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+#[cfg(target_os = "windows")]
+pub const PATH_ENV_SEPARATOR: char = ';';
+
+#[cfg(unix)]
+pub const PATH_ENV_SEPARATOR: char = ':';
+
+pub fn add_to_minimal_path<A: AsRef<Path>>(a: A) -> String {
+    format!(
+        "{}{}{}",
+        a.as_ref().to_str().unwrap(),
+        PATH_ENV_SEPARATOR,
+        MINIMAL_PATH
+    )
+}

--- a/tests/suite/common/temp_home_dir.rs
+++ b/tests/suite/common/temp_home_dir.rs
@@ -3,6 +3,7 @@ use crate::common::{
     executable::{create_executable, wait_until_file_is_not_busy},
     file_contents,
     file_contents::bash_script,
+    paths::MINIMAL_PATH,
     project_dirs, Settings,
 };
 use itertools::Itertools;
@@ -44,8 +45,24 @@ impl TempHomeDir {
         self.tempdir.path()
     }
 
-    pub fn dfx_cache_versions_dir(&self) -> PathBuf {
-        self.path().join(".cache").join("dfinity").join("versions")
+    pub fn dfinity_cache_dir(&self) -> PathBuf {
+        self.join(".cache").join("dfinity")
+    }
+
+    pub fn legacy_uninstall_script_path(&self) -> PathBuf {
+        self.dfinity_cache_dir().join("uninstall.sh")
+    }
+
+    pub fn dfinity_cache_versions_dir(&self) -> PathBuf {
+        self.dfinity_cache_dir().join("versions")
+    }
+
+    pub fn cache_downloads_path(&self) -> PathBuf {
+        self.dfinity_cache_dir().join("downloads")
+    }
+
+    pub fn cache_pulled_path(&self) -> PathBuf {
+        self.dfinity_cache_dir().join("pulled")
     }
 
     pub fn join<P: AsRef<Path>>(&self, path: P) -> PathBuf {
@@ -68,7 +85,7 @@ impl TempHomeDir {
         let mut command = Command::new(program.as_ref());
 
         command.env_clear();
-        command.env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
+        command.env("PATH", MINIMAL_PATH);
         command.env("HOME", self.path());
         if let Some(xdg_data_home) = &self.xdg_data_home {
             command.env("XDG_DATA_HOME", xdg_data_home);

--- a/tests/suite/dfxvm/self_uninstall.rs
+++ b/tests/suite/dfxvm/self_uninstall.rs
@@ -38,7 +38,7 @@ fn self_uninstall() {
         .assert()
         .success();
 
-    populate_dfx_cache_versions(&home_dir, &fake_dfx);
+    populate_dfinity_cache(&home_dir, &fake_dfx);
     populate_local_network_dir(&home_dir);
 
     std::fs::write(home_dir.installed_bin_dir().join("junk"), "junk").unwrap();
@@ -57,7 +57,7 @@ fn self_uninstall() {
         let expected = FAKE_RC.to_owned() + &posix_source();
         assert_eq!(rc, expected, "rc: {}", rc_path.display());
     }
-    assert!(home_dir.dfx_cache_versions_dir().exists());
+    assert!(home_dir.dfinity_cache_versions_dir().exists());
     assert!(all_process_exe_paths().contains(&home_dir.dfx_version_path("0.15.0")));
 
     home_dir
@@ -78,7 +78,7 @@ fn self_uninstall() {
         let expected = FAKE_RC.to_owned() + "\n";
         assert_eq!(rc, expected);
     }
-    assert!(!home_dir.dfx_cache_versions_dir().exists());
+    assert!(!home_dir.dfinity_cache_dir().exists());
     assert!(!all_process_exe_paths().contains(&home_dir.dfx_version_path("0.15.0")));
     assert!(!home_dir.data_local_dir().exists());
 
@@ -91,13 +91,26 @@ fn populate_local_network_dir(temp_home_dir: &TempHomeDir) {
     std::fs::write(dir.join("webserver-port"), "7654").unwrap();
 }
 
-fn populate_dfx_cache_versions(home_dir: &TempHomeDir, fake_dfx: &[u8]) {
+fn populate_dfinity_cache(home_dir: &TempHomeDir, fake_dfx: &[u8]) {
+    std::fs::create_dir_all(home_dir.cache_pulled_path()).unwrap();
+    std::fs::write(home_dir.cache_pulled_path().join("a-file"), "whatever").unwrap();
+    std::fs::create_dir_all(home_dir.cache_downloads_path()).unwrap();
+    std::fs::write(
+        home_dir.cache_downloads_path().join("dfx-0.7.2.tar.gz"),
+        "ok",
+    )
+    .unwrap();
+    std::fs::write(
+        home_dir.legacy_uninstall_script_path(),
+        "#!/usr/bin/env bash\necho uninstall",
+    )
+    .unwrap();
     populate_dfx_cache_version("0.15.0", home_dir, fake_dfx);
     populate_dfx_cache_version("0.14.4", home_dir, fake_dfx);
 }
 
 fn populate_dfx_cache_version(version: &str, home_dir: &TempHomeDir, fake_dfx: &[u8]) {
-    let dir = home_dir.dfx_cache_versions_dir().join(version);
+    let dir = home_dir.dfinity_cache_versions_dir().join(version);
     std::fs::create_dir_all(&dir).unwrap();
     std::fs::write(dir.join("dfx"), fake_dfx).unwrap();
 }


### PR DESCRIPTION
# Description

This PR makes `dfxvm-init` delete dfx wherever it is found on the PATH, except for dfxvm's bin directory.   This is necessary because even though the env file prepends the dfxvm bin directory to the PATH, /usr/local/bin ends up before it.

`dfxvm-init` now also deletes ~/.cache/dfinity/uninstall.sh, and `dfxvm self uninstall` deletes ~/.cache/dfinity entirely.

Fixes https://dfinity.atlassian.net/browse/SDK-1276

# How Has This Been Tested?

Added tests, and tested the `sudo rm` flow directly.

# Checklist:

- [x] I have edited the CHANGELOG accordingly.

