### PR TITLE
docs: move links to end of file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ to easily switch between different versions.
 
 ## Documentation
 
-See the [command-line reference](https://internetcomputer.org/docs/current/references/dfxvm/docs/cli-reference/dfx/) for
+See the [command-line reference][cli-reference] for
 documentation on using dfxvm.
 
 ## Installation
@@ -27,19 +27,22 @@ DFX_VERSION=0.15.1 sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinit
 ## Contribution
 
 Contributions to dfxvm are welcome! For information about contributing,
-see [CONTRIBUTING.md](https://github.com/dfinity/dfxvm/blob/main/CONTRIBUTING.md). Contributors must agree to a [CLA][cla].
+see [CONTRIBUTING.md][contributing]. Contributors must agree to a [CLA][cla].
 
 ## License
 
 Copyright 2023 DFINITY Stiftung <sdk@dfinity.org>.
 
-dfxvm is licensed under the [Apache 2.0 License](https://github.com/dfinity/dfxvm/blob/main/LICENSE).
+dfxvm is licensed under the [Apache 2.0 License][license].
 
 ## Acknowledgements
 
 dfxvm is inspired by, and parts are copied from and/or derived from, [rustup][rustup],
-which is also licensed under the [Apache 2.0 License](https://github.com/dfinity/dfxvm/blob/main/LICENSE).
+which is also licensed under the [Apache 2.0 License][license].
 
-[sdk]: https://github.com/dfinity/sdk
 [cla]: https://github.com/dfinity/cla/blob/main/CLA.md
+[cli-reference]: https://internetcomputer.org/docs/current/references/dfxvm/docs/cli-reference/dfx/
+[contributing]: https://github.com/dfinity/dfxvm/blob/main/CONTRIBUTING.md
+[license]: https://github.com/dfinity/dfxvm/blob/main/LICENSE
 [rustup]: https://github.com/rust-lang/rustup
+[sdk]: https://github.com/dfinity/sdk


### PR DESCRIPTION
This just moves the links to the bottom and alphabetizes them