### PR TITLE
feat: download cargo-dist-style release tarballs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 - Downloads new cargo-dist style tarballs from the release page.
+- Breaking change: Variables in the download URL template are now `{{version}}`, `{{basename}}`, and `{{archive-format}}`
 
 ## [0.2.1] - 2024-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+- Downloads new cargo-dist style tarballs from the release page.
+
 ## [0.2.1] - 2024-02-05
 
 - Removed openssl dependencies.

--- a/docs/settings-json-schema.json
+++ b/docs/settings-json-schema.json
@@ -11,9 +11,9 @@
       "type": "string"
     },
     "download_url_template": {
-      "description": "The template for the URL of a dfx release tarball.  The template can contain the following variables: {{version}}: The dfx version; {{arch}}: The machine architecture: \"x86_64\"; {{platform}}: The machine platform: \"linux\" or \"darwin\"",
+      "description": "The template for the URL of a dfx release tarball.  The template can contain the following variables: {{version}}: The dfx version; {{basename}}: either \"dfx-x86_64-unknown-linux-gnu\" or \"dfx-x86_64-apple-darwin\"; {{archive-format}}: \"tar.gz\"",
       "type": "string",
-      "default": "https://github.com/dfinity/sdk/releases/download/{{version}}/dfx-{{version}}-{{arch}}-{{platform}}.tar.gz"
+      "default": "https://github.com/dfinity/sdk/releases/download/{{version}}/{{basename}}.{{archive-format}}"
     },
     "manifest_url": {
       "description": "The URL of the dfx public manifest",

--- a/src/dfxvm/install.rs
+++ b/src/dfxvm/install.rs
@@ -107,7 +107,11 @@ fn format_tarball_basename() -> &'static str {
     basename
 }
 
-fn format_tarball_url(version: &Version, basename: &str, settings: &Settings) -> Result<Url, url::ParseError> {
+fn format_tarball_url(
+    version: &Version,
+    basename: &str,
+    settings: &Settings,
+) -> Result<Url, url::ParseError> {
     let url_template = settings.download_url_template();
     let url = url_template
         .replace("{{version}}", &version.to_string())

--- a/src/dfxvm/install.rs
+++ b/src/dfxvm/install.rs
@@ -55,7 +55,8 @@ pub async fn install(version: Version, locations: &Locations) -> Result<(), Inst
 
     extract_binary(&downloaded_tarball_path, install_dir.path())?;
 
-    rename(install_dir.path(), &version_dir)?;
+    let tarball_basename = format_tarball_basename();
+    rename(&install_dir.path().join(tarball_basename), &version_dir)?;
 
     info!("installed dfx {version}");
 
@@ -67,12 +68,13 @@ async fn download_verified_tarball(
     download_dir: &Path,
     settings: &Settings,
 ) -> Result<PathBuf, DownloadVerifiedTarballError> {
-    let tarball_filename = "dfx.tar.gz";
+    let tarball_basename = format_tarball_basename();
+    let tarball_filename = format!("{tarball_basename}.tar.gz");
     let shasum_filename = format!("{tarball_filename}.sha256");
     let downloaded_tarball_path = download_dir.join(tarball_filename);
     let downloaded_shasum_path = download_dir.join(shasum_filename);
 
-    let tarball_url = format_tarball_url(version, settings)?;
+    let tarball_url = format_tarball_url(version, tarball_basename, settings)?;
     let shasum_url = Url::parse(&format!("{tarball_url}.sha256"))?;
 
     let client = Client::new();
@@ -97,18 +99,20 @@ async fn download_verified_tarball(
     Ok(downloaded_tarball_path)
 }
 
-fn format_tarball_url(version: &Version, settings: &Settings) -> Result<Url, url::ParseError> {
+fn format_tarball_basename() -> &'static str {
     #[cfg(target_os = "linux")]
-    let platform = "linux";
+    let basename = "dfx-x86_64-unknown-linux-gnu";
     #[cfg(target_os = "macos")]
-    let platform = "darwin";
-    let arch = "x86_64";
+    let basename = "dfx-x86_64-apple-darwin";
+    basename
+}
 
+fn format_tarball_url(version: &Version, basename: &str, settings: &Settings) -> Result<Url, url::ParseError> {
     let url_template = settings.download_url_template();
     let url = url_template
         .replace("{{version}}", &version.to_string())
-        .replace("{{arch}}", arch)
-        .replace("{{platform}}", platform);
+        .replace("{{basename}}", basename)
+        .replace("{{archive-format}}", "tar.gz");
     Url::parse(&url)
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::Path;
 
-const DEFAULT_DOWNLOAD_URL_TEMPLATE: &str = "https://github.com/dfinity/sdk/releases/download/{{version}}/dfx-{{version}}-{{arch}}-{{platform}}.tar.gz";
+const DEFAULT_DOWNLOAD_URL_TEMPLATE: &str = "https://github.com/dfinity/sdk/releases/download/{{version}}/{{basename}}.{{archive-format}}";
 const DEFAULT_DFXVM_LATEST_DOWNLOAD_ROOT_URL: &str =
     "https://github.com/dfinity/dfxvm/releases/latest/download";
 const DEFAULT_MANIFEST_URL: &str = "https://sdk.dfinity.org/manifest.json";

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::Path;
 
-const DEFAULT_DOWNLOAD_URL_TEMPLATE: &str = "https://github.com/dfinity/sdk/releases/download/{{version}}/{{basename}}.{{archive-format}}";
+const DEFAULT_DOWNLOAD_URL_TEMPLATE: &str =
+    "https://github.com/dfinity/sdk/releases/download/{{version}}/{{basename}}.{{archive-format}}";
 const DEFAULT_DFXVM_LATEST_DOWNLOAD_ROOT_URL: &str =
     "https://github.com/dfinity/dfxvm/releases/latest/download";
 const DEFAULT_MANIFEST_URL: &str = "https://sdk.dfinity.org/manifest.json";

--- a/tests/suite/common/file_contents.rs
+++ b/tests/suite/common/file_contents.rs
@@ -33,7 +33,7 @@ pub fn manifest_json(latest: &str) -> String {
             "0.5.2"
         ]
     })
-        .to_string()
+    .to_string()
 }
 
 pub fn dist_manifest_json(latest: &str) -> String {
@@ -45,18 +45,19 @@ pub fn dist_manifest_json(latest: &str) -> String {
             }
         ]
     })
-        .to_string()
+    .to_string()
 }
 
 pub fn dfx_tarball(contents: &[u8]) -> Vec<u8> {
     let dirname = ReleaseAsset::dfx_tarball_basename();
     let include_docs = false;
+
     tool_tarball("dfx", dirname, contents, include_docs)
 }
 
 pub fn dfxvm_tarball(contents: &[u8]) -> Vec<u8> {
-    let include_docs = true;
     let dirname = ReleaseAsset::dfxvm_tarball_basename();
+    let include_docs = true;
 
     tool_tarball("dfxvm", &dirname, contents, include_docs)
 }

--- a/tests/suite/common/file_contents.rs
+++ b/tests/suite/common/file_contents.rs
@@ -51,7 +51,7 @@ pub fn dist_manifest_json(latest: &str) -> String {
 pub fn dfx_tarball(contents: &[u8]) -> Vec<u8> {
     let dirname = ReleaseAsset::dfx_tarball_basename();
     let include_docs = false;
-    tool_tarball("dfx", &dirname, contents, include_docs)
+    tool_tarball("dfx", dirname, contents, include_docs)
 }
 
 pub fn dfxvm_tarball(contents: &[u8]) -> Vec<u8> {
@@ -74,17 +74,17 @@ pub fn tool_tarball(tool: &str, dirname: &str, contents: &[u8], include_docs: bo
     let mut tar = Builder::new(Vec::new());
 
     if include_docs {
-        append_file(&mut tar, 0o644, &dirname, "README.md", b"the readme\n");
+        append_file(&mut tar, 0o644, dirname, "README.md", b"the readme\n");
         append_file(
             &mut tar,
             0o644,
-            &dirname,
+            dirname,
             "CHANGELOG.md",
             b"the changelog\n",
         );
     }
-    append_file(&mut tar, 0o644, &dirname, "LICENSE", b"the license\n");
-    append_file(&mut tar, 0o755, &dirname, tool, contents);
+    append_file(&mut tar, 0o644, dirname, "LICENSE", b"the license\n");
+    append_file(&mut tar, 0o755, dirname, tool, contents);
 
     let mut gzipped = GzEncoder::new(tar_buffer, Compression::default());
     gzipped.write_all(&tar.into_inner().unwrap()).unwrap();

--- a/tests/suite/common/file_contents.rs
+++ b/tests/suite/common/file_contents.rs
@@ -6,31 +6,6 @@ use sha2::{Digest, Sha256};
 use std::io::Write;
 use tar::Builder;
 
-/// make a .tar.gz that looks like a dfx release tarball
-/// $ tar -tvf dfx-0.15.1-x86_64-darwin.tar.gz
-// -rwxr-xr-x  0 runner staff 128330472 Oct  5 00:45 dfx
-/// $ tar -xvf dfx-0.15.1-x86_64-darwin.tar.gz
-/// x dfx
-/// $ ls -l dfx
-/// -rwxr-xr-x    1 ericswanson  staff  128330472 Oct  5 00:45 dfx
-pub fn binary_tar_gz(binary_name: &str, contents: &[u8]) -> Vec<u8> {
-    let tar_buffer = Vec::new();
-    let mut tar = Builder::new(Vec::new());
-
-    let mut file_header = tar::Header::new_gnu();
-    file_header.set_mode(0o755); // Make it executable
-    file_header.set_size(contents.len() as u64);
-    file_header.set_cksum();
-
-    tar.append_data(&mut file_header, binary_name, contents)
-        .unwrap();
-
-    let mut gzipped = GzEncoder::new(tar_buffer, Compression::default());
-    gzipped.write_all(&tar.into_inner().unwrap()).unwrap();
-
-    gzipped.finish().unwrap()
-}
-
 /// generate same format as output of `shasum -a 256 <filename>`
 pub fn sha256(filename: &str, contents: &[u8]) -> String {
     let hash = hex::encode(Sha256::digest(contents));
@@ -58,7 +33,7 @@ pub fn manifest_json(latest: &str) -> String {
             "0.5.2"
         ]
     })
-    .to_string()
+        .to_string()
 }
 
 pub fn dist_manifest_json(latest: &str) -> String {
@@ -70,7 +45,20 @@ pub fn dist_manifest_json(latest: &str) -> String {
             }
         ]
     })
-    .to_string()
+        .to_string()
+}
+
+pub fn dfx_tarball(contents: &[u8]) -> Vec<u8> {
+    let dirname = ReleaseAsset::dfx_tarball_basename();
+    let include_docs = false;
+    tool_tarball("dfx", &dirname, contents, include_docs)
+}
+
+pub fn dfxvm_tarball(contents: &[u8]) -> Vec<u8> {
+    let include_docs = true;
+    let dirname = ReleaseAsset::dfxvm_tarball_basename();
+
+    tool_tarball("dfxvm", &dirname, contents, include_docs)
 }
 
 // dfxvm tarball looks like:
@@ -81,22 +69,22 @@ pub fn dist_manifest_json(latest: &str) -> String {
 // -rw-r--r--  0 501    20      11357 Dec 19 11:21 dfxvm-aarch64-apple-darwin/LICENSE
 // -rwxr-xr-x  0 501    20    5747075 Dec 19 11:24 dfxvm-aarch64-apple-darwin/dfxvm
 
-pub fn dfxvm_tarball(contents: &[u8]) -> Vec<u8> {
-    let dirname = ReleaseAsset::dfxvm_tarball_basename();
-
+pub fn tool_tarball(tool: &str, dirname: &str, contents: &[u8], include_docs: bool) -> Vec<u8> {
     let tar_buffer = Vec::new();
     let mut tar = Builder::new(Vec::new());
 
-    append_file(&mut tar, 0o644, &dirname, "README.md", b"the readme\n");
-    append_file(
-        &mut tar,
-        0o644,
-        &dirname,
-        "CHANGELOG.md",
-        b"the changelog\n",
-    );
+    if include_docs {
+        append_file(&mut tar, 0o644, &dirname, "README.md", b"the readme\n");
+        append_file(
+            &mut tar,
+            0o644,
+            &dirname,
+            "CHANGELOG.md",
+            b"the changelog\n",
+        );
+    }
     append_file(&mut tar, 0o644, &dirname, "LICENSE", b"the license\n");
-    append_file(&mut tar, 0o755, &dirname, "dfxvm", contents);
+    append_file(&mut tar, 0o755, &dirname, tool, contents);
 
     let mut gzipped = GzEncoder::new(tar_buffer, Compression::default());
     gzipped.write_all(&tar.into_inner().unwrap()).unwrap();

--- a/tests/suite/common/file_contents.rs
+++ b/tests/suite/common/file_contents.rs
@@ -76,13 +76,7 @@ pub fn tool_tarball(tool: &str, dirname: &str, contents: &[u8], include_docs: bo
 
     if include_docs {
         append_file(&mut tar, 0o644, dirname, "README.md", b"the readme\n");
-        append_file(
-            &mut tar,
-            0o644,
-            dirname,
-            "CHANGELOG.md",
-            b"the changelog\n",
-        );
+        append_file(&mut tar, 0o644, dirname, "CHANGELOG.md", b"the changelog\n");
     }
     append_file(&mut tar, 0o644, dirname, "LICENSE", b"the license\n");
     append_file(&mut tar, 0o755, dirname, tool, contents);

--- a/tests/suite/common/mod.rs
+++ b/tests/suite/common/mod.rs
@@ -5,7 +5,6 @@ pub mod project_dirs;
 mod release_asset;
 mod release_server;
 mod settings;
-mod target;
 mod temp_home_dir;
 
 pub use release_asset::ReleaseAsset;

--- a/tests/suite/common/release_asset.rs
+++ b/tests/suite/common/release_asset.rs
@@ -1,10 +1,9 @@
 use crate::common::{
     file_contents,
-    file_contents::{bash_script},
+    file_contents::{bash_script, dfx_tarball},
 };
 use httptest::http::{response, Response};
 use semver::Version;
-use crate::common::file_contents::dfx_tarball;
 
 #[derive(Clone)]
 pub struct ReleaseAsset {
@@ -55,10 +54,10 @@ impl ReleaseAsset {
 
     pub fn dfx_tarball_basename() -> &'static str {
         #[cfg(target_os = "macos")]
-            let filename = "dfx-x86_64-apple-darwin";
+        let basename = "dfx-x86_64-apple-darwin";
         #[cfg(target_os = "linux")]
-            let filename = "dfx-x86_64-unknown-linux-gnu";
-        filename
+        let basename = "dfx-x86_64-unknown-linux-gnu";
+        basename
     }
 
     pub fn dfx_tarball_filename() -> String {
@@ -69,11 +68,11 @@ impl ReleaseAsset {
 
     pub fn dfxvm_tarball_basename() -> String {
         #[cfg(target_arch = "aarch64")]
-            let arch_and_os = "aarch64-apple-darwin";
+        let arch_and_os = "aarch64-apple-darwin";
         #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-            let arch_and_os = "x86_64-apple-darwin";
+        let arch_and_os = "x86_64-apple-darwin";
         #[cfg(target_os = "linux")]
-            let arch_and_os = "x86_64-unknown-linux-gnu";
+        let arch_and_os = "x86_64-unknown-linux-gnu";
 
         format!("dfxvm-{}", arch_and_os)
     }

--- a/tests/suite/common/release_asset.rs
+++ b/tests/suite/common/release_asset.rs
@@ -1,7 +1,6 @@
 use crate::common::{
     file_contents,
     file_contents::{bash_script},
-    target,
 };
 use httptest::http::{response, Response};
 use semver::Version;

--- a/tests/suite/common/release_server.rs
+++ b/tests/suite/common/release_server.rs
@@ -63,12 +63,12 @@ impl ReleaseServer {
                 "GET",
                 "/dfxvm-latest-download-root/dist-manifest.json",
             ))
-                .respond_with(
-                    response::Builder::new()
-                        .status(200)
-                        .body(contents.as_bytes().to_vec())
-                        .unwrap(),
-                ),
+            .respond_with(
+                response::Builder::new()
+                    .status(200)
+                    .body(contents.as_bytes().to_vec())
+                    .unwrap(),
+            ),
         );
     }
 }

--- a/tests/suite/common/release_server.rs
+++ b/tests/suite/common/release_server.rs
@@ -11,7 +11,7 @@ impl ReleaseServer {
     pub fn new(home_dir: &TempHomeDir) -> Self {
         let server = Server::run();
         let download_url_template = server.url_str(
-            "/any/arbitrary/path/{{version}}/dfx-{{version}}-{{arch}}-{{platform}}.tar.gz",
+            "/any/arbitrary/path/{{version}}/{{basename}}.{{archive-format}}",
         );
         home_dir
             .settings()
@@ -63,12 +63,12 @@ impl ReleaseServer {
                 "GET",
                 "/dfxvm-latest-download-root/dist-manifest.json",
             ))
-            .respond_with(
-                response::Builder::new()
-                    .status(200)
-                    .body(contents.as_bytes().to_vec())
-                    .unwrap(),
-            ),
+                .respond_with(
+                    response::Builder::new()
+                        .status(200)
+                        .body(contents.as_bytes().to_vec())
+                        .unwrap(),
+                ),
         );
     }
 }

--- a/tests/suite/common/release_server.rs
+++ b/tests/suite/common/release_server.rs
@@ -10,9 +10,8 @@ pub struct ReleaseServer {
 impl ReleaseServer {
     pub fn new(home_dir: &TempHomeDir) -> Self {
         let server = Server::run();
-        let download_url_template = server.url_str(
-            "/any/arbitrary/path/{{version}}/{{basename}}.{{archive-format}}",
-        );
+        let download_url_template =
+            server.url_str("/any/arbitrary/path/{{version}}/{{basename}}.{{archive-format}}");
         home_dir
             .settings()
             .write_download_url_template(&download_url_template);

--- a/tests/suite/common/target.rs
+++ b/tests/suite/common/target.rs
@@ -1,7 +1,0 @@
-pub fn platform() -> &'static str {
-    #[cfg(target_os = "linux")]
-    let platform = "linux";
-    #[cfg(target_os = "macos")]
-    let platform = "darwin";
-    platform
-}


### PR DESCRIPTION
# Description

Download the new release tarballs, which store the dfx binary in a subdirectory of the same name as the archive.  This matches the structure of the release archives that cargo-dist makes, and is more consistent with release tarballs in general (though there are no strict rules).

Fixes https://dfinity.atlassian.net/browse/SDK-1360

# How Has This Been Tested?

Installed dfx 0..5.2, 0.9.3, 0.16.0, and 0.16.1-cargodist.4 (actually created with cargo-dist) on OSX and WSL.

# Checklist:

- [x] I have edited the CHANGELOG accordingly.
