### PR TITLE
fix: disable dfx upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Downloads new cargo-dist style tarballs from the release page.
 - Breaking change: Variables in the download URL template are now `{{version}}`, `{{basename}}`, and `{{archive-format}}`
+- dfx mode disallows the `dfx upgrade` command, which would replace the versioned dfx executable.
 
 ## [0.2.1] - 2024-02-05
 

--- a/src/dfx.rs
+++ b/src/dfx.rs
@@ -56,7 +56,7 @@ fn trying_to_call_dfx_upgrade(args: &[OsString]) -> bool {
 
     let mut skip_next = false;
 
-    while let Some(arg) = iter.next() {
+    for arg in iter {
         if skip_next {
             // Skip the next argument if it's a parameter value
             skip_next = false;
@@ -65,7 +65,7 @@ fn trying_to_call_dfx_upgrade(args: &[OsString]) -> bool {
 
         // Convert the argument to a string
         if let Some(arg_str) = arg.to_str() {
-            if arg_str.starts_with("-") {
+            if arg_str.starts_with('-') {
                 if arg_str == "--identity" || arg_str == "--network" || arg_str == "--logfile" {
                     // The next parameter is an argument, so skip it
                     skip_next = true;


### PR DESCRIPTION
# Description

If allowed to execute under dfxvm, `dfx upgrade` would overwrite the dfx executable in the versions directory.

Fixes https://dfinity.atlassian.net/browse/SDK-1361

# How Has This Been Tested?

Added a test and ran locally

# Checklist:

- [x] I have edited the CHANGELOG accordingly.
