### PR TITLE
fix: set DFX_VERSION and add dfx bin path to PATH when calling dfx proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+- Fixed: sets DFX_VERSION when proxying to dfx, so that `dfx +version <command>` overrides any version specified in dfx.json.
+- Fixed: prepends the dfx version bin directory to the PATH when proxying to dfx.
+
 ## [0.3.0] - 2024-02-07
 
 - Downloads new cargo-dist style tarballs from the release page.

--- a/docs/cli-reference/dfx/dfx.md
+++ b/docs/cli-reference/dfx/dfx.md
@@ -69,3 +69,9 @@ To configure the default dfx version, use the `dfxvm default` command:
 ```bash
 dfxvm default 0.15.1
 ```
+
+## Environment Variables
+
+When proxying to dfx, dfxvm alters the environment in two ways:
+- Sets `DFX_VERSION` to the version of dfx being used.
+- Prepends the bin directory for the dfx version to `PATH`.

--- a/src/dfx.rs
+++ b/src/dfx.rs
@@ -1,4 +1,5 @@
 use crate::dfxvm::cleanup_self_updater;
+use crate::env::prepend_to_path;
 use crate::error::dfx;
 use crate::error::dfx::Error::Exec;
 use crate::error::dfx::{
@@ -41,6 +42,8 @@ pub fn main(args: &[OsString], locations: &Locations) -> Result<ExitCode, dfx::E
 
     let mut command = std::process::Command::new(bin_path);
     command.args(args);
+    command.env("DFX_VERSION", version.to_string());
+    command.env("PATH", prepend_to_path(&locations.version_dir(&version)));
     let err = command.exec();
     Err(Exec {
         command,

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,5 +1,11 @@
 use crate::error::env::{GetCurrentDirError, GetCurrentExeError, NoHomeDirectoryError};
-use std::path::PathBuf;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "windows")]
+const PATH_ENV_SEPARATOR: &str = ";";
+#[cfg(unix)]
+const PATH_ENV_SEPARATOR: &str = ":";
 
 pub fn current_dir() -> Result<PathBuf, GetCurrentDirError> {
     Ok(std::env::current_dir()?)
@@ -19,4 +25,15 @@ pub fn home_dir() -> Result<PathBuf, NoHomeDirectoryError> {
 pub fn use_xdg_data_home() -> bool {
     // See https://github.com/dirs-dev/directories-rs/blob/main/src/lin.rs#L15
     matches!(std::env::var_os("XDG_DATA_HOME"), Some(p) if PathBuf::from(&p).is_absolute())
+}
+
+pub fn prepend_to_path(dir_to_prepend: &Path) -> OsString {
+    let path = std::env::var_os("PATH").unwrap_or_default();
+
+    let mut path_with_dfx_version_dir =
+        OsString::with_capacity(dir_to_prepend.as_os_str().len() + 1 + path.as_os_str().len());
+    path_with_dfx_version_dir.push(dir_to_prepend.as_os_str());
+    path_with_dfx_version_dir.push(PATH_ENV_SEPARATOR);
+    path_with_dfx_version_dir.push(path.as_os_str());
+    path_with_dfx_version_dir
 }

--- a/tests/suite/common/paths.rs
+++ b/tests/suite/common/paths.rs
@@ -9,7 +9,7 @@ pub const PATH_ENV_SEPARATOR: char = ';';
 #[cfg(unix)]
 pub const PATH_ENV_SEPARATOR: char = ':';
 
-pub fn add_to_minimal_path<A: AsRef<Path>>(a: A) -> String {
+pub fn prepend_to_minimal_path<A: AsRef<Path>>(a: A) -> String {
     format!(
         "{}{}{}",
         a.as_ref().to_str().unwrap(),

--- a/tests/suite/dfxvm_init.rs
+++ b/tests/suite/dfxvm_init.rs
@@ -1,5 +1,5 @@
 use crate::common::{
-    file_contents::manifest_json, paths::add_to_minimal_path, ReleaseAsset, ReleaseServer,
+    file_contents::manifest_json, paths::prepend_to_minimal_path, ReleaseAsset, ReleaseServer,
     TempHomeDir,
 };
 use assert_cmd::prelude::*;
@@ -755,7 +755,7 @@ fn deletes_dfx_on_path() {
     home_dir
         .dfxvm_init()
         .arg("--yes")
-        .env("PATH", add_to_minimal_path(&another_bin_dir))
+        .env("PATH", prepend_to_minimal_path(&another_bin_dir))
         .assert()
         .success()
         .stderr(is_match("deleted:.*another-bin-dir/dfx").unwrap());
@@ -779,7 +779,10 @@ fn does_not_delete_dfx_proxy() {
     home_dir
         .dfxvm_init()
         .arg("--yes")
-        .env("PATH", add_to_minimal_path(home_dir.installed_bin_dir()))
+        .env(
+            "PATH",
+            prepend_to_minimal_path(home_dir.installed_bin_dir()),
+        )
         .assert()
         .success()
         .stderr(contains("deleted:").not());
@@ -799,7 +802,10 @@ fn copes_with_nonexistent_dir_on_path() {
     home_dir
         .dfxvm_init()
         .arg("--yes")
-        .env("PATH", add_to_minimal_path(home_dir.join("does-not-exist")))
+        .env(
+            "PATH",
+            prepend_to_minimal_path(home_dir.join("does-not-exist")),
+        )
         .assert()
         .success();
 }
@@ -821,7 +827,10 @@ fn removes_dfx_uninstall_script() {
     home_dir
         .dfxvm_init()
         .arg("--yes")
-        .env("PATH", add_to_minimal_path(home_dir.join("does-not-exist")))
+        .env(
+            "PATH",
+            prepend_to_minimal_path(home_dir.join("does-not-exist")),
+        )
         .assert()
         .success();
 


### PR DESCRIPTION
# Description

When proxying to dfx:
- set DFX_VERSION so that dfx doesn't in turn forward to something else
- prepend the dfx bin path to PATH so that any calls to dfx in package.json or build scripts will go to the right place

All dfx binaries to date look at DFX_VERSION and the "dfx" field in dfx json.  If these indicate to use a different version of dfx, they forward to that version instead.  By setting DFX_VERSION, we ensure that dfx won't forward to a different version.

Previous installed versions of dfx were installed to /usr/local/bin.  While it's likely that the dfxvm bin directory is on the path, adding the dfx version bin directory to the path will ensure that any calls to dfx go to the right version.

Fixes https://dfinity.atlassian.net/browse/SDK-1362

# How Has This Been Tested?

Added a test.   Also:

Before:
```
$ echo '{ "dfx": "0.14.4" }' >dfx.json
$ ./dfx +0.15.0 cache show
Warning: The version of DFX used (0.14.4) is different than the version being run (0.15.0).
This might happen because your dfx.json specifies an older version, or DFX_VERSION is set in your environment.
We are forwarding the command line to the old version. To disable this warning, set the DFX_WARNING=-version_check environment variable.

/Users/ericswanson/.cache/dfinity/versions/0.14.4
```

After:
```
 $ ./dfx +0.15.0 cache show
/Users/ericswanson/.cache/dfinity/versions/0.15.0
```

For the path piece, I tried calling `dfx deploy` (through the dfxvm proxy) without having the dfxvm bin dir on the path.

Before:
```
$ export PATH='<path without dfxvm bin directory>'
$ "/Users/ericswanson/Library/Application Support/org.dfinity.dfx/bin"/dfx deploy
Error: Failed while trying to deploy canisters.
/var/folders/7l/6w8kktld2xn8qfz_m84bx18c0000gn/T/generate-595dfa1d.sh: line 1: dfx: command not found
```


After:
```
$ ~/test-dfxvm/dfx build
...
Building frontend...
WARN: Building canisters before generate for Motoko
WARN: /Users/ericswanson/.cache/dfinity/versions/0.16.1/base/Array.mo:864.40-864.54: warning [M0155], operator may trap for inferred type
  Nat

Generating type declarations for canister dd_backend:
  src/declarations/dd_backend/dd_backend.did.d.ts
  src/declarations/dd_backend/dd_backend.did.js
  src/declarations/dd_backend/dd_backend.did

$
```

# Checklist:

- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation in docs/cli-reference.
