### PR TITLE
chore: escape brackets for mdx parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ see [CONTRIBUTING.md][contributing]. Contributors must agree to a [CLA][cla].
 
 ## License
 
-Copyright 2023 DFINITY Stiftung <sdk@dfinity.org>.
+Copyright 2023 DFINITY Stiftung \<sdk@dfinity.org\>.
 
 dfxvm is licensed under the [Apache 2.0 License][license].
 


### PR DESCRIPTION
This is to compile for the v3 mdx parser to render in the Portal.