### PR TITLE
feat: `dfxvm --list` now supports listing the remote available dfx versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
-- `dfxvm --list` now supports listing the remote available dfx versions.
-  - `--available`: Specifies to list the remote available versions.
-  - `--limit`: Specifies the number of remote versions to be listed in reverse chronological order, with default value `10`.
+- `dfxvm --list` now supports listing the available dfx versions.
+  - `--available`: Specifies to list the available versions.
+  - `--limit`: Specifies the number of available versions to be listed in reverse chronological order, with default value `10`.
 
 ## [1.0.0] - 2024-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 - `dfxvm --list` now supports listing the available dfx versions.
-  - `--available`: Specifies to list the available versions.
-  - `--limit`: Specifies the number of available versions to be listed in reverse chronological order, with default value `10`.
+  - `--available`: List the available versions.
+  - `--limit`: The maximum number of available versions to list in reverse chronological order, with default value `10`.
 
 ## [1.0.0] - 2024-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+- `dfxvm --list` now supports listing the remote available dfx versions.
+  - `--remote`: Specifies to list the available remote versions.
+  - `--number`: Specifies the number of remote versions to be listed in reverse chronological order, with default value `10`.
+
 ## [1.0.0] - 2024-02-20
 
 ## [0.3.1] - 2024-02-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 
 - `dfxvm --list` now supports listing the remote available dfx versions.
-  - `--remote`: Specifies to list the available remote versions.
-  - `--number`: Specifies the number of remote versions to be listed in reverse chronological order, with default value `10`.
+  - `--available`: Specifies to list the remote available versions.
+  - `--limit`: Specifies the number of remote versions to be listed in reverse chronological order, with default value `10`.
 
 ## [1.0.0] - 2024-02-20
 

--- a/docs/cli-reference/dfxvm/dfxvm-list.mdx
+++ b/docs/cli-reference/dfxvm/dfxvm-list.mdx
@@ -4,12 +4,16 @@ import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 
 <MarkdownChipRow labels={["Reference"]} />
 
-Lists the installed versions of dfx.
+List installed or available versions of dfx.
 
 ## Usage
 
 ```bash
-dfxvm list
+dfxvm list [OPTIONS]
+
+Options:
+    --available      List the available versions
+    --limit <LIMIT>  The maximum number of available versions to list, in reverse chronological order [default: 10]
 ```
 
 ## Examples
@@ -19,4 +23,44 @@ $ dfxvm list
 0.14.4
 0.15.1 (default)
 0.15.2-beta.1
+```
+
+```bash
+$ dfxvm list --available
+info: fetching https://sdk.dfinity.org/manifest.json
+0.24.3
+0.24.2
+0.24.1
+0.24.0
+0.23.0
+0.22.0
+0.21.0
+0.20.1
+0.20.0
+0.19.0
+```
+
+```bash
+$ dfxvm list --available --limit 20
+info: fetching https://sdk.dfinity.org/manifest.json
+0.24.3
+0.24.2
+0.24.1
+0.24.0
+0.23.0
+0.22.0
+0.21.0
+0.20.1
+0.20.0
+0.19.0
+0.18.0
+0.17.0
+0.16.1
+0.16.0
+0.15.3
+0.15.2
+0.15.1
+0.15.0
+0.14.4
+0.14.3
 ```

--- a/src/dfxvm.rs
+++ b/src/dfxvm.rs
@@ -2,6 +2,7 @@ mod cli;
 mod default;
 mod install;
 mod list;
+mod manifest;
 mod self_uninstall;
 mod self_update;
 mod uninstall;

--- a/src/dfxvm/cli.rs
+++ b/src/dfxvm/cli.rs
@@ -42,14 +42,14 @@ pub struct DefaultOpts {
     version: Option<Version>,
 }
 
-/// List installed or remote available versions of dfx
+/// List installed or available versions of dfx
 #[derive(Parser)]
 pub struct ListOpts {
-    /// Specifies to list the remote available versions.
+    /// Specifies to list the available versions.
     #[arg(long)]
     pub available: bool,
 
-    /// Specifies the number of remote versions to be listed, in reverse chronological order.
+    /// Specifies the number of available versions to be listed, in reverse chronological order.
     #[arg(long, default_value_t = 10, requires("available"))]
     pub limit: usize,
 }

--- a/src/dfxvm/cli.rs
+++ b/src/dfxvm/cli.rs
@@ -44,7 +44,15 @@ pub struct DefaultOpts {
 
 /// List installed versions of dfx
 #[derive(Parser)]
-pub struct ListOpts {}
+pub struct ListOpts {
+    /// Specifies to list the available remote versions.
+    #[arg(long)]
+    pub remote: bool,
+
+    /// Specifies the number of remote versions to be listed, in reverse chronological order.
+    #[arg(long, default_value_t = 10, requires("remote"))]
+    pub number: usize,
+}
 
 /// Uninstall a version of dfx
 #[derive(Parser)]
@@ -89,7 +97,7 @@ pub async fn main(args: &[OsString], locations: &Locations) -> Result<ExitCode, 
     match cli.command {
         Command::Default(opts) => default(opts.version, locations).await?,
         Command::Install(opts) => install(opts.version, locations).await?,
-        Command::List(_opts) => list(locations)?,
+        Command::List(opts) => list(opts, locations).await?,
         Command::SelfCmd(opts) => match opts.command {
             SelfCommand::Update(_opts) => self_update(locations).await?,
             SelfCommand::Uninstall(opts) => self_uninstall(opts.yes, locations)?,

--- a/src/dfxvm/cli.rs
+++ b/src/dfxvm/cli.rs
@@ -42,16 +42,16 @@ pub struct DefaultOpts {
     version: Option<Version>,
 }
 
-/// List installed versions of dfx
+/// List installed or remote available versions of dfx
 #[derive(Parser)]
 pub struct ListOpts {
-    /// Specifies to list the available remote versions.
+    /// Specifies to list the remote available versions.
     #[arg(long)]
-    pub remote: bool,
+    pub available: bool,
 
     /// Specifies the number of remote versions to be listed, in reverse chronological order.
-    #[arg(long, default_value_t = 10, requires("remote"))]
-    pub number: usize,
+    #[arg(long, default_value_t = 10, requires("available"))]
+    pub limit: usize,
 }
 
 /// Uninstall a version of dfx

--- a/src/dfxvm/cli.rs
+++ b/src/dfxvm/cli.rs
@@ -45,11 +45,11 @@ pub struct DefaultOpts {
 /// List installed or available versions of dfx
 #[derive(Parser)]
 pub struct ListOpts {
-    /// Specifies to list the available versions.
+    /// List the available versions.
     #[arg(long)]
     pub available: bool,
 
-    /// Specifies the number of available versions to be listed, in reverse chronological order.
+    /// The maximum number of available versions to list, in reverse chronological order.
     #[arg(long, default_value_t = 10, requires("available"))]
     pub limit: usize,
 }

--- a/src/dfxvm/list.rs
+++ b/src/dfxvm/list.rs
@@ -10,20 +10,17 @@ use semver::Version;
 
 pub async fn list(opts: ListOpts, locations: &Locations) -> Result<(), ListError> {
     let settings = Settings::load_or_default(&locations.settings_path())?;
-    if opts.remote {
+    if opts.available {
         let url = Url::parse(&settings.manifest_url())?;
 
         info!("fetching {url}");
         let manifest = fetch_json::<Manifest>(&url).await?;
 
-        if manifest.versions.is_empty() {
-            println!("No versions available.");
-        } else {
-            println!("Available versions:");
-            let count = std::cmp::min(opts.number, manifest.versions.len());
+        if !manifest.versions.is_empty() {
+            let count = std::cmp::min(opts.limit, manifest.versions.len());
             let versions = manifest.versions.iter().rev().take(count);
             for version in versions {
-                println!("  {}", version);
+                println!("{}", version);
             }
         }
     } else {

--- a/src/dfxvm/list.rs
+++ b/src/dfxvm/list.rs
@@ -23,7 +23,7 @@ pub async fn list(opts: ListOpts, locations: &Locations) -> Result<(), ListError
             let count = std::cmp::min(opts.number, manifest.versions.len());
             let versions = manifest.versions.iter().rev().take(count);
             for version in versions {
-                println!("  {}", version.to_string());
+                println!("  {}", version);
             }
         }
     } else {

--- a/src/dfxvm/list.rs
+++ b/src/dfxvm/list.rs
@@ -16,12 +16,10 @@ pub async fn list(opts: ListOpts, locations: &Locations) -> Result<(), ListError
         info!("fetching {url}");
         let manifest = fetch_json::<Manifest>(&url).await?;
 
-        if !manifest.versions.is_empty() {
-            let count = std::cmp::min(opts.limit, manifest.versions.len());
-            let versions = manifest.versions.iter().rev().take(count);
-            for version in versions {
-                println!("{}", version);
-            }
+        let count = std::cmp::min(opts.limit, manifest.versions.len());
+        let versions = manifest.versions.iter().rev().take(count);
+        for version in versions {
+            println!("{}", version);
         }
     } else {
         let default_version = settings.default_version;

--- a/src/dfxvm/list.rs
+++ b/src/dfxvm/list.rs
@@ -1,20 +1,42 @@
+use crate::dfxvm::cli::ListOpts;
+use crate::dfxvm::manifest::Manifest;
 use crate::error::dfxvm::ListError;
+use crate::json::fetch_json;
 use crate::locations::Locations;
 use crate::settings::Settings;
 use itertools::Itertools;
+use reqwest::Url;
 use semver::Version;
 
-pub fn list(locations: &Locations) -> Result<(), ListError> {
+pub async fn list(opts: ListOpts, locations: &Locations) -> Result<(), ListError> {
     let settings = Settings::load_or_default(&locations.settings_path())?;
-    let default_version = settings.default_version;
+    if opts.remote {
+        let url = Url::parse(&settings.manifest_url())?;
 
-    for version in installed_versions(locations)? {
-        let default_indicator = if default_version.as_ref() == Some(&version) {
-            " (default)"
+        info!("fetching {url}");
+        let manifest = fetch_json::<Manifest>(&url).await?;
+
+        if manifest.versions.is_empty() {
+            println!("No versions available.");
         } else {
-            ""
-        };
-        println!("{}{}", version, default_indicator);
+            println!("Available versions:");
+            let count = std::cmp::min(opts.number, manifest.versions.len());
+            let versions = manifest.versions.iter().rev().take(count);
+            for version in versions {
+                println!("  {}", version.to_string());
+            }
+        }
+    } else {
+        let default_version = settings.default_version;
+
+        for version in installed_versions(locations)? {
+            let default_indicator = if default_version.as_ref() == Some(&version) {
+                " (default)"
+            } else {
+                ""
+            };
+            println!("{}{}", version, default_indicator);
+        }
     }
     Ok(())
 }

--- a/src/dfxvm/manifest.rs
+++ b/src/dfxvm/manifest.rs
@@ -1,0 +1,13 @@
+use semver::Version;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct Tags {
+    pub latest: Version,
+}
+
+#[derive(Deserialize)]
+pub struct Manifest {
+    pub tags: Tags,
+    pub versions: Vec<Version>,
+}

--- a/src/dfxvm/update.rs
+++ b/src/dfxvm/update.rs
@@ -1,11 +1,10 @@
 use crate::dfxvm::default::set_default;
+use crate::dfxvm::manifest::Manifest;
 use crate::error::dfxvm::UpdateError;
 use crate::json::fetch_json;
 use crate::locations::Locations;
 use crate::settings::Settings;
 use reqwest::Url;
-use semver::Version;
-use serde::Deserialize;
 
 pub async fn update(locations: &Locations) -> Result<(), UpdateError> {
     let settings = Settings::load_or_default(&locations.settings_path())?;
@@ -20,14 +19,4 @@ pub async fn update(locations: &Locations) -> Result<(), UpdateError> {
     set_default(&latest_version, locations).await?;
 
     Ok(())
-}
-
-#[derive(Deserialize)]
-struct Tags {
-    latest: Version,
-}
-
-#[derive(Deserialize)]
-struct Manifest {
-    tags: Tags,
 }

--- a/src/error/dfxvm.rs
+++ b/src/error/dfxvm.rs
@@ -46,8 +46,14 @@ pub enum Error {
 
 #[derive(Error, Debug)]
 pub enum ListError {
+    #[error("failed to fetch versions")]
+    FetchVersions(#[from] FetchJsonDocError),
+
     #[error(transparent)]
     LoadJsonFile(#[from] LoadJsonFileError),
+
+    #[error("failed to parse manifest url")]
+    ParseManifestUrl(#[from] url::ParseError),
 
     #[error("failed to read directory {path}")]
     ReadDir {

--- a/src/error/dfxvm.rs
+++ b/src/error/dfxvm.rs
@@ -46,7 +46,7 @@ pub enum Error {
 
 #[derive(Error, Debug)]
 pub enum ListError {
-    #[error("failed to fetch versions")]
+    #[error(transparent)]
     FetchVersions(#[from] FetchJsonDocError),
 
     #[error(transparent)]

--- a/tests/suite/dfxvm/list.rs
+++ b/tests/suite/dfxvm/list.rs
@@ -100,11 +100,10 @@ fn remote_versions() {
     home_dir
         .dfxvm()
         .arg("list")
-        .arg("--remote")
+        .arg("--available")
         .assert()
         .success()
         .stderr(is_match("info: fetching http://.*/manifest.json").unwrap())
-        .stdout(contains("Available versions:"))
         .stdout(contains("0.5.2"))
         .stdout(contains("0.5.0"));
 }

--- a/tests/suite/dfxvm/list.rs
+++ b/tests/suite/dfxvm/list.rs
@@ -104,6 +104,26 @@ fn remote_versions() {
         .assert()
         .success()
         .stderr(is_match("info: fetching http://.*/manifest.json").unwrap())
-        .stdout(contains("0.5.2"))
-        .stdout(contains("0.5.0"));
+        .stdout(contains("0.5.2").count(1))
+        .stdout(contains("0.5.0").count(1));
+}
+
+#[test]
+fn remote_versions_with_limit() {
+    let home_dir = TempHomeDir::new();
+    let server = ReleaseServer::new(&home_dir);
+
+    server.expect_get_manifest(&manifest_json("0.14.6"));
+
+    home_dir
+        .dfxvm()
+        .arg("list")
+        .arg("--available")
+        .arg("--limit")
+        .arg("1")
+        .assert()
+        .success()
+        .stderr(is_match("info: fetching http://.*/manifest.json").unwrap())
+        .stdout(contains("0.5.2").count(1))
+        .stdout(contains("0.5.0").count(0));
 }


### PR DESCRIPTION
# Description

`dfxvm --list` now supports listing the available dfx versions.
  - `--available`: List the available versions.
  - `--limit`:The maximum number of available versions to list in reverse chronological order, with default value `10`.

Fixes # (issue)

[SDK-1883](https://dfinity.atlassian.net/browse/SDK-1883)

# How Has This Been Tested?

1. Manually tested
2. Test added.

# Checklist:

- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation in docs/cli-reference.


[SDK-1883]: https://dfinity.atlassian.net/browse/SDK-1883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ