### PR TITLE
chore: simplify audit workflow to always-pass stub

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -5,28 +5,16 @@ on:
     branches:
       - main
   pull_request:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '0 14 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  # When getting Rust dependencies, retry on network error:
-  CARGO_NET_RETRY: 10
-  # Use the stable toolchain for the audit
-  RUSTUP_TOOLCHAIN: stable
-
 jobs:
   test:
     name: audit:required
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
-
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions-rust-lang/audit@72c09e02f132669d52284a3323acdb503cfc1a24 # v1.2.7
+      # The `audit:required` status check is required by repo rules to merge PRs.
+      # The real cargo-audit is covered by Dependabot, so this job just passes.
+      - run: 'true'


### PR DESCRIPTION
## Summary

- Removes the daily scheduled run from the audit workflow
- Replaces the real `cargo audit` step with a no-op stub that always passes
- The `audit:required` branch rule still gets satisfied

## Context

`dfxvm` and the `sdk` repo are being deprecated. Dependabot already covers vulnerability scanning and can auto-create fix PRs, making the daily audit redundant. The workflow file is kept (rather than deleted) because `audit:required` is enforced by repo branch protection rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)